### PR TITLE
Replace parity-wasm with wasmparser in analyze crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,7 +388,7 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc19683171f287921f2405677dd2ed2549c3b3bda697a563ebc3a121ace2aba1"
 dependencies = [
- "async-lock 3.3.0",
+ "async-lock",
  "blocking",
  "futures-lite",
 ]
@@ -399,26 +399,17 @@ version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcccb0f599cfa2f8ace422d3555572f47424da5648a4382a9dd0310ff8210884"
 dependencies = [
- "async-lock 3.3.0",
+ "async-lock",
  "cfg-if",
  "concurrent-queue",
  "futures-io",
  "futures-lite",
  "parking",
  "polling",
- "rustix 0.38.32",
+ "rustix 0.38.34",
  "slab",
  "tracing",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "async-lock"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "287272293e9d8c41773cec55e365490fe034813a2f172f502d6ddcf75b2f582b"
-dependencies = [
- "event-listener 2.5.3",
 ]
 
 [[package]]
@@ -445,40 +436,40 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "2.2.1"
+version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cad07b3443bfa10dcddf86a452ec48949e8e7fedf7392d82de3969fda99e90ed"
+checksum = "a53fc6301894e04a92cb2584fedde80cb25ba8e02d9dc39d4a87d036e22f397d"
 dependencies = [
  "async-channel",
  "async-io",
- "async-lock 3.3.0",
+ "async-lock",
  "async-signal",
  "async-task",
  "blocking",
  "cfg-if",
  "event-listener 5.3.0",
  "futures-lite",
- "rustix 0.38.32",
+ "rustix 0.38.34",
  "tracing",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "async-signal"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e47d90f65a225c4527103a8d747001fc56e375203592b25ad103e1ca13124c5"
+checksum = "afe66191c335039c7bb78f99dc7520b0cbb166b3a1cb33a03f53d8a1c6f2afda"
 dependencies = [
  "async-io",
- "async-lock 2.8.0",
+ "async-lock",
  "atomic-waker",
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 0.38.32",
+ "rustix 0.38.34",
  "signal-hook-registry",
  "slab",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -712,7 +703,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a37913e8dc4ddcc604f0c6d3bf2887c995153af3611de9e23c352b44c1b9118"
 dependencies = [
  "async-channel",
- "async-lock 3.3.0",
+ "async-lock",
  "async-task",
  "fastrand",
  "futures-io",
@@ -954,12 +945,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f6e324229dc011159fcc089755d1e2e216a90d43a7dea6853ca740b84f35e7"
+checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
 dependencies = [
  "jobserver",
  "libc",
+ "once_cell",
 ]
 
 [[package]]
@@ -1160,7 +1152,7 @@ version = "4.1.1"
 dependencies = [
  "anyhow",
  "contract-metadata",
- "wasmparser 0.204.0",
+ "wasmparser 0.205.0",
  "wat",
 ]
 
@@ -1198,7 +1190,7 @@ dependencies = [
  "uzers",
  "wabt",
  "walkdir",
- "wasm-encoder 0.204.0",
+ "wasm-encoder",
  "wasm-opt",
  "wasmparser 0.205.0",
  "which",
@@ -1897,12 +1889,6 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "event-listener"
 version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
@@ -1991,9 +1977,9 @@ dependencies = [
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c007b1ae3abe1cb6f85a16305acd418b7ca6343b953633fee2b76d8f108b830f"
+checksum = "38793c55593b33412e3ae40c2c9781ffaa6f438f6f8c10f24e71846fbd7ae01e"
 
 [[package]]
 name = "fixed-hash"
@@ -2946,9 +2932,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jobserver"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "685a7d121ee3f65ae4fddd72b25a04bb36b6af81bc0828f7d5434c0fe60fa3a2"
+checksum = "d2b099aaa34a9751c5bf0878add70444e1ed2dd73f347be99003d4577277de6e"
 dependencies = [
  "libc",
 ]
@@ -3287,7 +3273,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
 dependencies = [
- "rustix 0.38.32",
+ "rustix 0.38.34",
 ]
 
 [[package]]
@@ -3850,15 +3836,15 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.6.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c976a60b2d7e99d6f229e414670a9b85d13ac305cc6d1e9c134de58c5aaaf6"
+checksum = "645493cf344456ef24219d02a768cf1fb92ddf8c92161679ae3d91b91a637be3"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix 0.38.32",
+ "rustix 0.38.34",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -4327,9 +4313,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.32"
+version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65e04861e65f21776e67888bfbea442b3642beaa0138fdb1dd7a84a52dffdb89"
+checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
  "bitflags 2.5.0",
  "errno",
@@ -4352,14 +4338,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.3"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99008d7ad0bbbea527ec27bddbc0e432c5b87d8175178cee68d2eec9c4a1813c"
+checksum = "bf4ef73721ac7bcd79b2b315da7779d8fc09718c6b3d2d1b2d94850eb8c18432"
 dependencies = [
  "log",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.2",
+ "rustls-webpki 0.102.3",
  "subtle",
  "zeroize",
 ]
@@ -4410,9 +4396,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.4.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd36cc4259e3e4514335c4a138c6b43171a8d61d8f5c9348f9fc7529416f247"
+checksum = "beb461507cee2c2ff151784c52762cf4d9ff6a61f3e80968600ed24fa837fa54"
 
 [[package]]
 name = "rustls-webpki"
@@ -4426,9 +4412,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.2"
+version = "0.102.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faaa0a62740bedb9b2ef5afa303da42764c012f743917351dc9a237ea1663610"
+checksum = "f3bce581c0dd41bce533ce695a1437fa16a7ab5ac3ccfa99fe1a620a7885eabf"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -5032,9 +5018,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
 ]
@@ -5092,7 +5078,7 @@ dependencies = [
  "async-executor",
  "async-fs",
  "async-io",
- "async-lock 3.3.0",
+ "async-lock",
  "async-net",
  "async-process",
  "blocking",
@@ -5106,7 +5092,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6d1eaa97d77be4d026a1e7ffad1bb3b78448763b357ea6f8188d3e6f736a9b9"
 dependencies = [
  "arrayvec 0.7.4",
- "async-lock 3.3.0",
+ "async-lock",
  "atomic-take",
  "base64 0.21.7",
  "bip39",
@@ -5161,7 +5147,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5496f2d116b7019a526b1039ec2247dd172b8670633b1a64a614c9ea12c9d8c7"
 dependencies = [
  "async-channel",
- "async-lock 3.3.0",
+ "async-lock",
  "base64 0.21.7",
  "blake2-rfc",
  "derive_more",
@@ -5902,7 +5888,7 @@ checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
 dependencies = [
  "cfg-if",
  "fastrand",
- "rustix 0.38.32",
+ "rustix 0.38.34",
  "windows-sys 0.52.0",
 ]
 
@@ -6051,7 +6037,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
 dependencies = [
- "rustls 0.22.3",
+ "rustls 0.22.4",
  "rustls-pki-types",
  "tokio",
 ]
@@ -6091,7 +6077,7 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit 0.22.11",
+ "toml_edit 0.22.12",
 ]
 
 [[package]]
@@ -6138,9 +6124,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.11"
+version = "0.22.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb686a972ccef8537b39eead3968b0e8616cb5040dbb9bba93007c8e07c9215f"
+checksum = "d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef"
 dependencies = [
  "indexmap 2.2.6",
  "serde",
@@ -6593,15 +6579,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.205.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90e95b3563d164f33c1cfb0a7efbd5940c37710019be10cd09f800fdec8b0e5c"
-dependencies = [
- "leb128",
-]
-
-[[package]]
 name = "wasm-opt"
 version = "0.116.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6695,9 +6672,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser-nostd"
-version = "0.100.1"
+version = "0.100.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9157cab83003221bfd385833ab587a039f5d6fa7304854042ba358a3b09e0724"
+checksum = "d5a015fe95f3504a94bb1462c717aae75253e39b9dd6c3fb1062c934535c64aa"
 dependencies = [
  "indexmap-nostd",
 ]
@@ -6844,7 +6821,7 @@ dependencies = [
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.205.0",
+ "wasm-encoder",
 ]
 
 [[package]]
@@ -6874,7 +6851,7 @@ checksum = "8211e4f58a2b2805adfbefbc07bab82958fc91e3836339b1ab7ae32465dce0d7"
 dependencies = [
  "either",
  "home",
- "rustix 0.38.32",
+ "rustix 0.38.34",
  "winsafe",
 ]
 
@@ -6896,11 +6873,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+checksum = "134306a13c5647ad6453e8deaec55d3a44d6021970129e6188735e74bf546697"
 dependencies = [
- "winapi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7218,9 +7195,9 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+checksum = "63381fa6624bf92130a6b87c0d07380116f80b565c42cf0d754136f0238359ef"
 dependencies = [
  "zeroize_derive",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1151,8 +1151,8 @@ version = "4.1.1"
 dependencies = [
  "anyhow",
  "contract-metadata",
- "parity-wasm",
- "wabt",
+ "wasmparser 0.204.0",
+ "wat",
 ]
 
 [[package]]
@@ -1189,7 +1189,7 @@ dependencies = [
  "uzers",
  "wabt",
  "walkdir",
- "wasm-encoder",
+ "wasm-encoder 0.204.0",
  "wasm-opt",
  "wasmparser 0.204.0",
  "which",
@@ -3604,12 +3604,6 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
-
-[[package]]
-name = "parity-wasm"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1ad0aff30c1da14b1254fcb2af73e1fa9a28670e584a626f53a369d0e157304"
 
 [[package]]
 name = "parking"
@@ -6579,6 +6573,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.205.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90e95b3563d164f33c1cfb0a7efbd5940c37710019be10cd09f800fdec8b0e5c"
+dependencies = [
+ "leb128",
+]
+
+[[package]]
 name = "wasm-opt"
 version = "0.116.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6809,6 +6812,28 @@ dependencies = [
  "serde",
  "thiserror",
  "wasmparser 0.102.0",
+]
+
+[[package]]
+name = "wast"
+version = "205.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "441a6a195b3b5245e26d450bbcc91366c6b652382a22f63cbe3c73240e13b2bb"
+dependencies = [
+ "bumpalo",
+ "leb128",
+ "memchr",
+ "unicode-width",
+ "wasm-encoder 0.205.0",
+]
+
+[[package]]
+name = "wat"
+version = "1.205.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19832624d606e7c6bf3cd4caa73578ecec5eac30c768269256d19c79900beb18"
+dependencies = [
+ "wast",
 ]
 
 [[package]]

--- a/crates/analyze/Cargo.toml
+++ b/crates/analyze/Cargo.toml
@@ -15,10 +15,9 @@ include = ["Cargo.toml", "*.rs", "LICENSE"]
 
 [dependencies]
 contract-metadata = { version = "4.1.1", path = "../metadata" }
-parity-wasm = { version = "0.45.0" }
-#wasm-encoder = { version = "0.204.0", features = ["wasmparser"] }
 wasmparser = "0.204.0"
 anyhow = "1.0.81"
 
 [dev-dependencies]
-wabt = "0.10.0"
+wat = "1.205.0"
+

--- a/crates/analyze/Cargo.toml
+++ b/crates/analyze/Cargo.toml
@@ -15,7 +15,7 @@ include = ["Cargo.toml", "*.rs", "LICENSE"]
 
 [dependencies]
 contract-metadata = { version = "4.1.1", path = "../metadata" }
-wasmparser = "0.204.0"
+wasmparser = "0.205.0"
 anyhow = "1.0.81"
 
 [dev-dependencies]

--- a/crates/analyze/Cargo.toml
+++ b/crates/analyze/Cargo.toml
@@ -16,6 +16,8 @@ include = ["Cargo.toml", "*.rs", "LICENSE"]
 [dependencies]
 contract-metadata = { version = "4.1.1", path = "../metadata" }
 parity-wasm = { version = "0.45.0" }
+#wasm-encoder = { version = "0.204.0", features = ["wasmparser"] }
+wasmparser = "0.204.0"
 anyhow = "1.0.81"
 
 [dev-dependencies]

--- a/crates/analyze/src/lib.rs
+++ b/crates/analyze/src/lib.rs
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
-#![deny(unused_crate_dependencies)]
+//#![deny(unused_crate_dependencies)]
 
 use anyhow::{
     anyhow,
@@ -21,18 +21,6 @@ use anyhow::{
     Result,
 };
 pub use contract_metadata::Language;
-use core::ops::Range;
-use parity_wasm::elements::{
-    External,
-    FuncBody,
-    FunctionType,
-    ImportSection,
-    Instruction,
-    Module,
-    Type,
-    TypeSection,
-    ValueType,
-};
 use std::collections::HashMap;
 use wasmparser::{
     FuncType,
@@ -46,26 +34,28 @@ use wasmparser::{
     ValType,
 };
 
+/// WebAssembly module
 #[derive(Default)]
-struct ModuleInfo<'a> {
-    custom_sections: HashMap<String, Range<usize>>,
-    start_section: Option<(u32, Range<usize>)>,
-    // Function idx maps to type idx
-    functions: Vec<u32>,
-    // Types for inner functions
-    types: Vec<FuncType>,
-    imports: Vec<Import<'a>>,
-    bodies: Vec<Vec<Operator<'a>>>,
-    module_bytes: &'a [u8],
+pub struct Module<'a> {
+    // Map the custom section name to its data.
+    pub custom_sections: HashMap<&'a str, &'a [u8]>,
+    // Start section function.
+    pub start_section: Option<u32>,
+    // Map the function index to the type index.
+    pub function_sections: Vec<u32>,
+    // Type sections containing functions only.
+    pub type_sections: Vec<FuncType>,
+    // Import sections.
+    pub import_sections: Vec<Import<'a>>,
+    // Code sections containing instructions only.
+    pub code_sections: Vec<Vec<Operator<'a>>>,
 }
 
-impl<'a> ModuleInfo<'a> {
+impl<'a> Module<'a> {
+    /// Parse the Wasm module.
     fn parse(code: &'a [u8]) -> Result<Self> {
-        let mut module = Self {
-            module_bytes: code,
-            ..Default::default()
-        };
-        for payload in Parser::new(0).parse_all(module.module_bytes) {
+        let mut module: Module<'a> = Default::default();
+        for payload in Parser::new(0).parse_all(code) {
             let payload = payload?;
 
             match payload {
@@ -74,26 +64,21 @@ impl<'a> ModuleInfo<'a> {
                     encoding: wasmparser::Encoding::Component,
                     range: _,
                 } => {
-                    anyhow::bail!("Unsupported component section")
+                    anyhow::bail!("Unsupported component section.")
                 }
                 Payload::End(_) => break,
                 Payload::CustomSection(ref c) => {
-                    module
-                        .custom_sections
-                        .insert(c.name().to_string(), c.range());
+                    module.custom_sections.insert(c.name(), c.data());
                 }
-                Payload::StartSection { func, range } => {
-                    module.start_section = Some((func, range));
+                Payload::StartSection { func, range: _ } => {
+                    module.start_section = Some(func);
                 }
                 Payload::CodeSectionStart {
                     count: _,
                     range,
                     size: _,
                 } => {
-                    let reader = wasmparser::CodeSectionReader::new(
-                        &module.module_bytes[range],
-                        0,
-                    )?;
+                    let reader = wasmparser::CodeSectionReader::new(&code[range], 0)?;
                     for body in reader {
                         let body = body?;
                         let reader = body.get_operators_reader();
@@ -101,23 +86,23 @@ impl<'a> ModuleInfo<'a> {
                         let ops = operators
                             .into_iter()
                             .collect::<std::result::Result<Vec<_>, _>>()?;
-                        module.bodies.push(ops);
+                        module.code_sections.push(ops);
                     }
                 }
                 Payload::ImportSection(reader) => {
                     for ty in reader {
-                        module.imports.push(ty?);
+                        module.import_sections.push(ty?);
                     }
                 }
                 Payload::TypeSection(reader) => {
                     // Save function types
                     for ty in reader.into_iter_err_on_gc_types() {
-                        module.types.push(ty?);
+                        module.type_sections.push(ty?);
                     }
                 }
                 Payload::FunctionSection(reader) => {
                     for ty in reader {
-                        module.functions.push(ty?);
+                        module.function_sections.push(ty?);
                     }
                 }
                 _ => {}
@@ -126,29 +111,25 @@ impl<'a> ModuleInfo<'a> {
         Ok(module)
     }
 
+    /// Create a Module from the Wasm code.
     pub fn new(code: &'a [u8]) -> Result<Self> {
         Self::parse(code)
     }
 
-    /// Get custom section names.
-    pub fn custom_section_names(&self) -> Vec<String> {
-        self.custom_sections.keys().map(ToOwned::to_owned).collect()
-    }
-
-    /// Check if functiona name is present in the 'name' custom section
-    fn has_function_name(&self, name: &str) -> Result<bool> {
+    /// Check if the function name is present in the 'name' custom section.
+    pub fn has_function_name(&self, name: &str) -> Result<bool> {
         // The contract compiled in debug mode includes function names in the name
         // section.
         let name_section = self
             .custom_sections
             .get("name")
-            .ok_or_else(|| anyhow!("Not found"))?;
-        let reader = NameSectionReader::new(&self.module_bytes, name_section.start);
+            .ok_or(anyhow!("Custom section 'name' not found."))?;
+        let reader = NameSectionReader::new(name_section, 0);
         for section in reader {
-            if let Name::Function(n) = section? {
-                for e in n {
-                    let naming = e?;
-                    if naming.name == name {
+            if let Name::Function(name_reader) = section? {
+                for naming in name_reader {
+                    let naming = naming?;
+                    if naming.name.contains(name) {
                         return Ok(true)
                     }
                 }
@@ -157,86 +138,83 @@ impl<'a> ModuleInfo<'a> {
         Ok(false)
     }
 
-    pub fn has_start_section(&self) -> bool {
-        self.start_section.is_some()
-    }
-
-    fn get_function_type_index(&self, function: &FuncType) -> Result<usize> //body
-    {
-        for (i, ty) in self.types.iter().enumerate() {
+    /// Get the function's type index from the type section.
+    pub fn function_type_index(&self, function: &FuncType) -> Option<usize> {
+        self.type_sections.iter().enumerate().find_map(|(i, ty)| {
             if ty == function {
-                return Ok(i)
+                return Some(i)
             }
-        }
-        bail!("Not found")
+            None
+        })
     }
 
-    fn get_function_import_index(&self, name: &str) -> Result<usize> //body
-    {
-        self.imports
+    /// Get the function index from the import section.
+    pub fn function_import_index(&self, name: &str) -> Option<usize> {
+        self.import_sections
             .iter()
             .filter(|&entry| matches!(entry.ty, TypeRef::Func(_)))
             .position(|e| e.name == name)
-            .ok_or(anyhow!("Missing required import for: {}", name))
     }
 
-    fn filter_function_by_type(
+    /// Search for a functions in a WebAssembly (Wasm) module that matches a given
+    /// function type.
+    ///
+    /// If one or more functions matching the specified type are found, this function
+    /// returns their bodies in a vector; otherwise, it returns an error.
+    pub fn functions_by_type(
         &self,
         function_type: &FuncType,
     ) -> Result<Vec<Vec<Operator>>> {
-        let func_type_index = self.get_function_type_index(function_type)?;
-        println!("function type index: {func_type_index}");
-
-        self.functions
+        self.function_sections
             .iter()
             .enumerate()
-            .filter(|(_, &elem)| elem == func_type_index as u32)
+            .filter(|(_, &elem)| {
+                Some(elem as usize) == self.function_type_index(function_type)
+            })
             .map(|(index, _)| {
-                self.bodies
+                self.code_sections
                     .get(index)
-                    .ok_or(anyhow!("Requested function not found code section"))
+                    .ok_or(anyhow!("Requested function not found in code section."))
                     .cloned()
             })
             .collect::<Result<Vec<_>>>()
     }
+}
 
-    /// Checks if a ink! function is present.
-    fn is_ink_function_present(&self) -> bool {
-        // Signature for 'deny_payment' ink! function.
-        let ink_func_deny_payment_sig = FuncType::new(vec![], vec![ValType::I32]);
-        // Signature for 'transferred_value' ink! function.
-        let ink_func_transferred_value_sig = FuncType::new(vec![ValType::I32], vec![]);
+/// Checks if a ink! function is present.
+fn is_ink_function_present(module: &Module) -> bool {
+    // Signature for 'deny_payment' ink! function.
+    let ink_func_deny_payment_sig = FuncType::new(vec![], vec![ValType::I32]);
+    // Signature for 'transferred_value' ink! function.
+    let ink_func_transferred_value_sig = FuncType::new(vec![ValType::I32], vec![]);
 
-        // The deny_payment and transferred_value functions internally call the
-        // value_transferred function. Getting its index from import section.
-        let value_transferred_index =
-        // For ink! >=4
-        self.get_function_import_index("value_transferred").or(
-            // For ink! ^3
-            self.get_function_import_index("seal_value_transferred"),
-        );
-        println!("value_transferred_index: {:?}", value_transferred_index);
+    // The deny_payment and transferred_value functions internally call the
+    // value_transferred function. Getting its index from import section.
+    let value_transferred_index =
+    // For ink! >=4
+    module.function_import_index("value_transferred").or(
+        // For ink! ^3
+        module.function_import_index("seal_value_transferred"),
+    );
 
-        let mut functions: Vec<Vec<Operator>> = Vec::new();
-        let function_signatures =
-            vec![&ink_func_deny_payment_sig, &ink_func_transferred_value_sig];
+    let mut functions: Vec<Vec<Operator>> = Vec::new();
+    let function_signatures =
+        vec![&ink_func_deny_payment_sig, &ink_func_transferred_value_sig];
 
-        for signature in function_signatures {
-            if let Ok(mut func) = self.filter_function_by_type(signature) {
-                functions.append(&mut func);
-            }
+    for signature in function_signatures {
+        if let Ok(mut func) = module.functions_by_type(signature) {
+            functions.append(&mut func);
         }
-        println!("functions {}", functions.len());
-        if let Ok(index) = value_transferred_index {
-            functions.iter().any(|body| {
-            body.iter().any(|instruction| {
-                // Matches the 'value_transferred' function.
-                matches!(instruction, &Operator::Call{function_index} if function_index as usize == index)
-            })
+    }
+    if let Some(index) = value_transferred_index {
+        functions.iter().any(|body| {
+        body.iter().any(|instruction| {
+            // Matches the 'value_transferred' function.
+            matches!(instruction, &Operator::Call{function_index} if function_index as usize == index)
         })
-        } else {
-            false
-        }
+    })
+    } else {
+        false
     }
 }
 
@@ -247,135 +225,26 @@ impl<'a> ModuleInfo<'a> {
 /// the contract's source language. It currently supports detection for Ink!, Solidity,
 /// and AssemblyScript languages.
 pub fn determine_language(code: &[u8]) -> Result<Language> {
-    let module = ModuleInfo::new(code)?;
+    let module = Module::new(code)?;
+    let start_section = module.start_section.is_some();
 
-    // let wasm_module: Module = parity_wasm::deserialize_buffer(code)?;
-    // let module = wasm_module.clone().parse_names().unwrap_or(wasm_module);
-    let start_section = module.has_start_section();
-
-    if !start_section
-        && module
-            .custom_section_names()
-            .iter()
-            .any(|e| e.as_str() == "producers")
-    {
+    if !start_section && module.custom_sections.keys().any(|e| e == &"producers") {
         return Ok(Language::Solidity)
     } else if start_section
         && module
-            .custom_section_names()
-            .iter()
-            .any(|e| e.as_str() == "sourceMappingURL")
+            .custom_sections
+            .keys()
+            .any(|e| e == &"sourceMappingURL")
     {
         return Ok(Language::AssemblyScript)
     } else if !start_section
-        && (module.is_ink_function_present()
+        && (is_ink_function_present(&module)
             || matches!(module.has_function_name("ink_env"), Ok(true)))
     {
         return Ok(Language::Ink)
     }
 
-    bail!("Language unsupported or unrecognized")
-}
-
-/// Checks if a ink! function is present.
-fn _is_ink_function_present(module: &Module) -> bool {
-    let import_section = module
-        .import_section()
-        .expect("Import setction shall be present");
-
-    // Signature for 'deny_payment' ink! function.
-    let ink_func_deny_payment_sig =
-        Type::Function(FunctionType::new(vec![], vec![ValueType::I32]));
-    // Signature for 'transferred_value' ink! function.
-    let ink_func_transferred_value_sig =
-        Type::Function(FunctionType::new(vec![ValueType::I32], vec![]));
-
-    // The deny_payment and transferred_value functions internally call the
-    // value_transferred function. Getting its index from import section.
-    let value_transferred_index =
-        // For ink! >=4
-        get_function_import_index(import_section, "value_transferred").or(
-            // For ink! ^3
-            get_function_import_index(import_section, "seal_value_transferred"),
-        );
-
-    let mut functions: Vec<&FuncBody> = Vec::new();
-    let function_signatures =
-        vec![&ink_func_deny_payment_sig, &ink_func_transferred_value_sig];
-
-    for signature in function_signatures {
-        if let Ok(mut func) = filter_function_by_type(module, signature) {
-            functions.append(&mut func);
-        }
-    }
-
-    if let Ok(index) = value_transferred_index {
-        functions.iter().any(|&body| {
-            body.code().elements().iter().any(|instruction| {
-                // Matches the 'value_transferred' function.
-                matches!(instruction, &Instruction::Call(i) if i as usize == index)
-            })
-        })
-    } else {
-        false
-    }
-}
-
-/// Get the function index from the import section.
-fn get_function_import_index(
-    import_section: &ImportSection,
-    field: &str,
-) -> Result<usize> {
-    import_section
-        .entries()
-        .iter()
-        .filter(|&entry| matches!(entry.external(), External::Function(_)))
-        .position(|e| e.field() == field)
-        .ok_or(anyhow!("Missing required import for: {}", field))
-}
-
-/// Get the function type index from the type section.
-fn get_function_type_index(
-    type_section: &TypeSection,
-    function_type: &Type,
-) -> Result<usize> {
-    type_section
-        .types()
-        .iter()
-        .position(|e| e == function_type)
-        .ok_or(anyhow!("Requested function type not found"))
-}
-
-/// Search for a functions in a WebAssembly (Wasm) module that matches a given function
-/// type.
-///
-/// If one or more functions matching the specified type are found, this function returns
-/// their bodies in a vector; otherwise, it returns an error.
-fn filter_function_by_type<'a>(
-    module: &'a Module,
-    function_type: &Type,
-) -> Result<Vec<&'a FuncBody>> {
-    let type_section = module
-        .type_section()
-        .ok_or(anyhow!("Missing required type section"))?;
-    let func_type_index = get_function_type_index(type_section, function_type)?;
-
-    module
-        .function_section()
-        .ok_or(anyhow!("Missing required function section"))?
-        .entries()
-        .iter()
-        .enumerate()
-        .filter(|(_, elem)| elem.type_ref() == func_type_index as u32)
-        .map(|(index, _)| {
-            module
-                .code_section()
-                .ok_or(anyhow!("Missing required code section"))?
-                .bodies()
-                .get(index)
-                .ok_or(anyhow!("Requested function not found code section"))
-        })
-        .collect::<Result<Vec<_>>>()
+    bail!("Language unsupported or unrecognized.")
 }
 
 #[cfg(test)]
@@ -394,12 +263,12 @@ mod tests {
             (func (;5;) (type 0))
         )
         "#;
-        let code = wabt::wat2wasm(contract).expect("invalid wabt");
-        let lang = determine_language(&code);
+        let code = &wat::parse_str(contract).expect("Invalid wat.");
+        let lang = determine_language(code);
         assert!(lang.is_err());
         assert_eq!(
             lang.unwrap_err().to_string(),
-            "Language unsupported or unrecognized"
+            "Language unsupported or unrecognized."
         );
     }
 
@@ -457,11 +326,11 @@ mod tests {
         )
             (global (;0;) (mut i32) (i32.const 65536))
         )"#;
-        let code = wabt::wat2wasm(contract).expect("invalid wabt");
-        let lang = determine_language(&code);
+        let code = &wat::parse_str(contract).expect("Invalid wat.");
+        let lang = determine_language(code);
         assert!(
             matches!(lang, Ok(Language::Ink)),
-            "Failed to detect Ink! language"
+            "Failed to detect Ink! language."
         );
     }
 
@@ -472,17 +341,14 @@ mod tests {
             (type (;0;) (func (param i32 i32 i32)))
             (import "env" "memory" (memory (;0;) 16 16))
             (func (;0;) (type 0))
+            (@custom "producers" "data")
         )
         "#;
-        let code = wabt::wat2wasm(contract).expect("invalid wabt");
-        // Custom sections are not supported in wabt format, injecting using parity_wasm
-        let mut module: Module = parity_wasm::deserialize_buffer(&code).unwrap();
-        module.set_custom_section("producers".to_string(), Vec::new());
-        let code = module.into_bytes().unwrap();
-        let lang = determine_language(&code);
+        let code = &wat::parse_str(contract).expect("Invalid wat.");
+        let lang = determine_language(code);
         assert!(
             matches!(lang, Ok(Language::Solidity)),
-            "Failed to detect Solidity language"
+            "Failed to detect Solidity language."
         );
     }
 
@@ -497,17 +363,14 @@ mod tests {
             (start $~start)
             (func $~start (type $none_=>_none))
             (func (;1;) (type 0))
+            (@custom "sourceMappingURL" "data")
         )
         "#;
-        let code = wabt::wat2wasm(contract).expect("invalid wabt");
-        // Custom sections are not supported in wabt format, injecting using parity_wasm
-        let mut module: Module = parity_wasm::deserialize_buffer(&code).unwrap();
-        module.set_custom_section("sourceMappingURL".to_string(), Vec::new());
-        let code = module.into_bytes().unwrap();
-        let lang = determine_language(&code);
+        let code = &wat::parse_str(contract).expect("Invalid wat.");
+        let lang = determine_language(code);
         assert!(
             matches!(lang, Ok(Language::AssemblyScript)),
-            "Failed to detect AssemblyScript language"
+            "Failed to detect AssemblyScript language."
         );
     }
 }

--- a/crates/analyze/src/lib.rs
+++ b/crates/analyze/src/lib.rs
@@ -191,11 +191,11 @@ fn is_ink_function_present(module: &Module) -> bool {
     // The deny_payment and transferred_value functions internally call the
     // value_transferred function. Getting its index from import section.
     let value_transferred_index =
-    // For ink! >=4
-    module.function_import_index("value_transferred").or(
-        // For ink! ^3
-        module.function_import_index("seal_value_transferred"),
-    );
+        // For ink! >=4
+        module.function_import_index("value_transferred").or(
+            // For ink! ^3
+            module.function_import_index("seal_value_transferred"),
+        );
 
     let mut functions: Vec<Vec<Operator>> = Vec::new();
     let function_signatures =

--- a/crates/analyze/src/lib.rs
+++ b/crates/analyze/src/lib.rs
@@ -13,7 +13,7 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
-//#![deny(unused_crate_dependencies)]
+#![deny(unused_crate_dependencies)]
 
 use anyhow::{
     anyhow,
@@ -37,17 +37,17 @@ use wasmparser::{
 /// WebAssembly module
 #[derive(Default)]
 pub struct Module<'a> {
-    // Map the custom section name to its data.
+    /// Map the custom section name to its data.
     pub custom_sections: HashMap<&'a str, &'a [u8]>,
-    // Start section function.
+    /// Start section function.
     pub start_section: Option<u32>,
-    // Map the function index to the type index.
+    /// Map the function index to the type index.
     pub function_sections: Vec<u32>,
-    // Type sections containing functions only.
+    /// Type sections containing functions only.
     pub type_sections: Vec<FuncType>,
-    // Import sections.
+    /// Import sections.
     pub import_sections: Vec<Import<'a>>,
-    // Code sections containing instructions only.
+    /// Code sections containing instructions only.
     pub code_sections: Vec<Vec<Operator<'a>>>,
 }
 
@@ -280,12 +280,10 @@ mod tests {
             (type (;1;) (func (result i32)))
             (type (;2;) (func (param i32 i32)))
             (import "seal" "foo" (func (;0;) (type 0)))
-            (import "seal" "foo1" (func (;1;) (type 0)))
-            (import "seal" "foo1" (func (;2;) (type 0)))
-            (import "seal0" "value_transferred" (func (;3;) (type 2)))
+            (import "seal0" "value_transferred" (func (;1;) (type 2)))
             (import "env" "memory" (memory (;0;) 2 16))
-            (func (;4;) (type 2))
-            (func (;5;) (type 1) (result i32)
+            (func (;2;) (type 2))
+            (func (;3;) (type 1) (result i32)
             (local i32 i64 i64)
             global.get 0
             i32.const 32
@@ -305,7 +303,7 @@ mod tests {
             local.get 0
             i32.const 28
             i32.add
-            call 3
+            call 1
             local.get 0
             i64.load offset=8
             local.set 1


### PR DESCRIPTION
## Summary
Closes #_
- [ ] y/n | Does it introduce breaking changes?
- [ ] y/n | Is it dependent on the specific version of `ink` or `pallet-contracts`?

Replace unsupported `parity-wasm` crate with `wasmparser`

## Description
`parity-wasm` crate is unsupported, so it has been replaced with `wasmparser` crate

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [ ] I have added an entry to `CHANGELOG.md`
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
