### PR TITLE
chore: Update toolchain for `ink_linting`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Updated the toolchain version used by `ink_linting` - [#1616](https://github.com/paritytech/cargo-contract/pull/1616)
+
 ## [4.1.1]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Modern releases of gcc and clang, as well as Visual Studio 2019+ should work.
 
     -   (MacOS) `brew install openssl`
     -   ```
-        export TOOLCHAIN_VERSION=nightly-2023-12-28
+        export TOOLCHAIN_VERSION=nightly-2024-02-08
         rustup install $TOOLCHAIN_VERSION
         rustup component add rust-src --toolchain $TOOLCHAIN_VERSION
         rustup run $TOOLCHAIN_VERSION cargo install cargo-dylint dylint-link

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -20,7 +20,7 @@ ARG WGET_VERSION=1.21-1+deb11u1
 ARG G_VERSION=4:10.2.1-1
 ARG MUSL_V=1.2.2-1
 # The rust version used by linter
-ARG RUST_LINTER_VERSION=nightly-2023-12-28
+ARG RUST_LINTER_VERSION=nightly-2024-02-08
 
 # metadata
 LABEL io.parity.image.vendor="Parity Technologies" \
@@ -105,7 +105,7 @@ RUN apt-get -y update && apt-get -y install gcc=${GCC_VERSION} g++=${G_VERSION} 
     && cargo install cargo-dylint dylint-link \
     # Check if build with linting works
     && cargo contract new test \
-    # Generate /usr/local/dylint_drivers/nightly-2023-12-28-x86_64-unknown-linux-gnu/dylint-driver bin
+    # Generate /usr/local/dylint_drivers/nightly-2024-02-08-x86_64-unknown-linux-gnu/dylint-driver bin
     && mkdir -p $DYLINT_DRIVER_PATH \
     && cd test && cargo contract build --lint --verbose --release && cd .. \
     && rm -rf test \

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -114,7 +114,7 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 pub(crate) mod linting {
     /// Toolchain used to build ink_linting:
     /// https://github.com/paritytech/ink/blob/master/linting/rust-toolchain.toml
-    pub const TOOLCHAIN_VERSION: &str = "nightly-2023-12-28";
+    pub const TOOLCHAIN_VERSION: &str = "nightly-2024-02-08";
     /// Git repository with ink_linting libraries
     pub const GIT_URL: &str = "https://github.com/paritytech/ink/";
     /// Git revision number of the linting crate

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -118,7 +118,7 @@ pub(crate) mod linting {
     /// Git repository with ink_linting libraries
     pub const GIT_URL: &str = "https://github.com/paritytech/ink/";
     /// Git revision number of the linting crate
-    pub const GIT_REV: &str = "b6880dd9384e09ec4e7ad65453cd844113e8a316";
+    pub const GIT_REV: &str = "ef91c60e52eb5d3ae80fd25082bc0a9468332e36";
 }
 
 /// Arguments to use when executing `build` or `check` commands.


### PR DESCRIPTION
## Summary
See: https://github.com/paritytech/ink/pull/2112

- [n] y/n | Does it introduce breaking changes?
- [y] y/n | Is it dependent on the specific version of `ink` or `pallet-contracts`?
<!--- Provide a general summary of your changes -->

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have added an entry to `CHANGELOG.md`
- [x] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
