### PR TITLE
Add new image deployment repo

### DIFF
--- a/.github/workflows/release-image.yml
+++ b/.github/workflows/release-image.yml
@@ -9,7 +9,7 @@ on:
       - prereleased
       - published
 env:
-  IMAGE_NAME: paritytech/contracts-verifiable
+  IMAGE_NAME: useink/contracts-verifiable
 
 jobs:
   push_to_registry:
@@ -34,7 +34,7 @@ jobs:
           file: ./build-image/Dockerfile
           push: true
           build-args: |
-            CARGO_CONTRACT_GIT=https://github.com/paritytech/cargo-contract
+            CARGO_CONTRACT_GIT=https://github.com/use-ink/cargo-contract
             CARGO_CONTRACT_BRANCH=master
           tags: |
             ${{ env.IMAGE_NAME }}:master
@@ -56,6 +56,6 @@ jobs:
           file: ./build-image/Dockerfile
           push: true
           build-args: |
-            CARGO_CONTRACT_GIT=https://github.com/paritytech/cargo-contract
+            CARGO_CONTRACT_GIT=https://github.com/use-ink/cargo-contract
             CARGO_CONTRACT_TAG=${{ github.event.release.tag_name }}
           tags: ${{ env.IMAGE_NAME }}:${{ env.DOCKER_TAG }}

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -23,24 +23,24 @@ ARG MUSL_V=1.2.2-1
 ARG RUST_LINTER_VERSION=nightly-2024-02-08
 
 # metadata
-LABEL io.use-ink.image.vendor="Use Ink" \
-    io.use-ink.image.title="useink/contracts-verifiable" \
-    io.use-ink.image.description="Inherits from docker.io/bitnami/minideb:bullseye. \
+LABEL ink.use.image.vendor="Use Ink" \
+    ink.use.image.title="useink/contracts-verifiable" \
+    ink.use.image.description="Inherits from docker.io/bitnami/minideb:bullseye. \
     rust nightly, clippy, rustfmt, miri, rust-src, rustc-dev, grcov, rust-covfix, \
     llvm-tools-preview, cargo-contract, xargo, binaryen, parallel, codecov, ink, solang" \
-    io.use-ink.image.documentation="https://github.com/use-ink/cargo-contract/blob/master/\
+    ink.use.image.documentation="https://github.com/use-ink/cargo-contract/blob/master/\
     build-image/README.md" \
-    io.use-ink.version.rust=${RUST_VERSION} \
-    io.use-ink.version.cargo-contract.version=${CARGO_CONTRACT_VERSION} \
-    io.use-ink.version.cargo-contract.git.repository=${CARGO_CONTRACT_GIT} \
-    io.use-ink.version.cargo-contract.git.branch=${CARGO_CONTRACT_BRANCH} \
-    io.use-ink.version.cargo-contract.git.revision=${CARGO_CONTRACT_REV} \
-    io.use-ink.version.cargo-contract.git.tag=${CARGO_CONTRACT_TAG} \
-    io.use-ink.version.gcc=${GCC_VERSION} \
-    io.use-ink.version.wget=${WGET_VERSION} \
-    io.use-ink.version.g_plus_plus=${G_VERSION} \
-    io.use-ink.version.musl=${MUSL_V} \
-    io.use-ink.version.rust_linter=${RUST_LINTER_VERSION}
+    ink.use.version.rust=${RUST_VERSION} \
+    ink.use.version.cargo-contract.version=${CARGO_CONTRACT_VERSION} \
+    ink.use.version.cargo-contract.git.repository=${CARGO_CONTRACT_GIT} \
+    ink.use.version.cargo-contract.git.branch=${CARGO_CONTRACT_BRANCH} \
+    ink.use.version.cargo-contract.git.revision=${CARGO_CONTRACT_REV} \
+    ink.use.version.cargo-contract.git.tag=${CARGO_CONTRACT_TAG} \
+    ink.use.version.gcc=${GCC_VERSION} \
+    ink.use.version.wget=${WGET_VERSION} \
+    ink.use.version.g_plus_plus=${G_VERSION} \
+    ink.use.version.musl=${MUSL_V} \
+    ink.use.version.rust_linter=${RUST_LINTER_VERSION}
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -23,24 +23,24 @@ ARG MUSL_V=1.2.2-1
 ARG RUST_LINTER_VERSION=nightly-2024-02-08
 
 # metadata
-LABEL io.parity.image.vendor="Parity Technologies" \
-    io.parity.image.title="paritytech/contracts-verifiable" \
-    io.parity.image.description="Inherits from docker.io/bitnami/minideb:bullseye. \
+LABEL io.use-ink.image.vendor="Use Ink" \
+    io.use-ink.image.title="useink/contracts-verifiable" \
+    io.use-ink.image.description="Inherits from docker.io/bitnami/minideb:bullseye. \
     rust nightly, clippy, rustfmt, miri, rust-src, rustc-dev, grcov, rust-covfix, \
     llvm-tools-preview, cargo-contract, xargo, binaryen, parallel, codecov, ink, solang" \
-    io.parity.image.documentation="https://github.com/paritytech/cargo-contract/blob/master/\
+    io.use-ink.image.documentation="https://github.com/use-ink/cargo-contract/blob/master/\
     build-image/README.md" \
-    io.parity.version.rust=${RUST_VERSION} \
-    io.parity.version.cargo-contract.version=${CARGO_CONTRACT_VERSION} \
-    io.parity.version.cargo-contract.git.repository=${CARGO_CONTRACT_GIT} \
-    io.parity.version.cargo-contract.git.branch=${CARGO_CONTRACT_BRANCH} \
-    io.parity.version.cargo-contract.git.revision=${CARGO_CONTRACT_REV} \
-    io.parity.version.cargo-contract.git.tag=${CARGO_CONTRACT_TAG} \
-    io.parity.version.gcc=${GCC_VERSION} \
-    io.parity.version.wget=${WGET_VERSION} \
-    io.parity.version.g_plus_plus=${G_VERSION} \
-    io.parity.version.musl=${MUSL_V} \
-    io.parity.version.rust_linter=${RUST_LINTER_VERSION}
+    io.use-ink.version.rust=${RUST_VERSION} \
+    io.use-ink.version.cargo-contract.version=${CARGO_CONTRACT_VERSION} \
+    io.use-ink.version.cargo-contract.git.repository=${CARGO_CONTRACT_GIT} \
+    io.use-ink.version.cargo-contract.git.branch=${CARGO_CONTRACT_BRANCH} \
+    io.use-ink.version.cargo-contract.git.revision=${CARGO_CONTRACT_REV} \
+    io.use-ink.version.cargo-contract.git.tag=${CARGO_CONTRACT_TAG} \
+    io.use-ink.version.gcc=${GCC_VERSION} \
+    io.use-ink.version.wget=${WGET_VERSION} \
+    io.use-ink.version.g_plus_plus=${G_VERSION} \
+    io.use-ink.version.musl=${MUSL_V} \
+    io.use-ink.version.rust_linter=${RUST_LINTER_VERSION}
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \


### PR DESCRIPTION
## Summary
Closes #_
- [ ] y/n | Does it introduce breaking changes?
- [ ] y/n | Is it dependent on the specific version of `ink` or `pallet-contracts`?
Change image deployment path to `useink/contracts-verifiable`

## Description
Change `paritytech/contracts-verifiable` to `useink/contracts-verifiable`
## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [ ] I have added an entry to `CHANGELOG.md`
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
