### PR TITLE
Switch to useink image in verifiable build command

### DIFF
--- a/build-image/README.md
+++ b/build-image/README.md
@@ -4,10 +4,6 @@ Docker image based on the minimalistic Debian image `bitnami/minideb:bullseye-am
 
 Used for reproducible builds in `cargo contract build --verifiable`
 
-**Rust versions:**
-
-Currently, the 1.69 toolchain is temporarily required to build ink! contracts because of https://github.com/paritytech/cargo-contract/issues/1139
-
 **Rust tools & toolchains:**
 
 We use stable releases from crates.io
@@ -15,7 +11,7 @@ We use stable releases from crates.io
 - `cargo-contract`
 - `wasm32-unknown-unknown`: The toolchain to compile Rust codebases for Wasm.
 
-[Click here](https://hub.docker.com/repository/docker/paritytech/contracts-verifiable) for the registry.
+[Click here](https://hub.docker.com/repository/docker/useink/contracts-verifiable) for the registry.
 
 ## Usage
 
@@ -26,7 +22,7 @@ and work directory is set to `/contract`. You need to mount the folder with the 
 docker run -d \
     --name ink-container \
     --mount type=bind,source="$(pwd)",target="/contract" \
-    paritytech/contracts-verifiable
+    useink/contracts-verifiable
 ```
 
 For multi-contract projects, like in the example below:
@@ -56,7 +52,7 @@ _Settings_ -> _Features in development_ tab in Docker Desktop App.
 Build docker image:
 
 ```bash
-docker buildx build -t paritytech/contracts-verifiable:0.0.1-local --build-arg CARGO_CONTRACT_VERSION=4.1.0 .
+docker buildx build -t useink/contracts-verifiable:0.0.1-local --build-arg CARGO_CONTRACT_VERSION=4.1.0 .
 ```
 
 Run docker container:
@@ -65,5 +61,5 @@ Run docker container:
 docker container run \
     -it --rm --entrypoint /bin/bash \
     --mount type=bind,source="$(pwd)",target="/contract" \
-    paritytech/contracts-verifiable:0.0.1-local
+    useink/contracts-verifiable:0.0.1-local
 ```

--- a/crates/build/src/docker.rs
+++ b/crates/build/src/docker.rs
@@ -95,7 +95,7 @@ use crate::{
 
 use colored::Colorize;
 /// Default image to be used for the build.
-const IMAGE: &str = "paritytech/contracts-verifiable";
+const IMAGE: &str = "useink/contracts-verifiable";
 /// We assume the docker image contains the same tag as the current version of the crate.
 const VERSION: &str = env!("CARGO_PKG_VERSION");
 /// The default directory to be mounted in the container.

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -116,7 +116,7 @@ pub(crate) mod linting {
     /// https://github.com/paritytech/ink/blob/master/linting/rust-toolchain.toml
     pub const TOOLCHAIN_VERSION: &str = "nightly-2024-02-08";
     /// Git repository with ink_linting libraries
-    pub const GIT_URL: &str = "https://github.com/paritytech/ink/";
+    pub const GIT_URL: &str = "https://github.com/use-ink/ink/";
     /// Git revision number of the linting crate
     pub const GIT_REV: &str = "ef91c60e52eb5d3ae80fd25082bc0a9468332e36";
 }


### PR DESCRIPTION
## Summary
Closes #_
- [ ] y/n | Does it introduce breaking changes?
- [ ] y/n | Is it dependent on the specific version of `ink` or `pallet-contracts`?
Change verifiable image url

## Description
Image has been moved from `paritytech` to `useink`

## Checklist before requesting a review
- [ ] My code follows the style guidelines of this project
- [ ] I have added an entry to `CHANGELOG.md`
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
