### PR TITLE
chore: bump subxt version to 0.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Updated the toolchain version used by `ink_linting` - [#1616](https://github.com/paritytech/cargo-contract/pull/1616)
+- Bump the version of `subxt` and `subxt-signer` - [#1721](https://github.com/use-ink/cargo-contract/pull/1721)
+
 
 ## [4.1.1]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -762,7 +762,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbe5b10e214954177fb1dc9fbd20a1a2608fe99e6c832033bdc7cea287a20d77"
 dependencies = [
  "borsh-derive",
- "cfg_aliases",
+ "cfg_aliases 0.1.1",
 ]
 
 [[package]]
@@ -954,6 +954,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -964,6 +970,12 @@ name = "cfg_aliases"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
@@ -1072,6 +1084,16 @@ checksum = "cbf2150cce219b664a8a70df7a1f933836724b503f8a413af9365b4dcc4d90b8"
 dependencies = [
  "lazy_static",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "combine"
+version = "4.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
+dependencies = [
+ "bytes",
+ "memchr",
 ]
 
 [[package]]
@@ -1618,6 +1640,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-where"
+version = "1.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.61",
+]
+
+[[package]]
 name = "derive_arbitrary"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1833,9 +1866,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.11.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "elliptic-curve"
@@ -1982,6 +2015,16 @@ name = "fiat-crypto"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38793c55593b33412e3ae40c2c9781ffaa6f438f6f8c10f24e71846fbd7ae01e"
+
+[[package]]
+name = "finito"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2384245d85162258a14b43567a9ee3598f5ae746a1581fb5d3d2cb780f0dbf95"
+dependencies = [
+ "futures-timer",
+ "pin-project",
+]
 
 [[package]]
 name = "fixed-hash"
@@ -2866,9 +2909,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
 ]
@@ -2939,6 +2982,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
+name = "jni"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6df18c2e3db7e453d3c6ac5b3e9d5182664d28788126d39b91f2d1e22b017ec"
+dependencies = [
+ "cesu8",
+ "combine",
+ "jni-sys",
+ "log",
+ "thiserror",
+ "walkdir",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
 name = "jobserver"
 version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2968,10 +3031,21 @@ version = "0.22.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfdb12a2381ea5b2e68c3469ec604a007b367778cdb14d09612c8069ebd616ad"
 dependencies = [
- "jsonrpsee-client-transport",
- "jsonrpsee-core",
+ "jsonrpsee-client-transport 0.22.5",
+ "jsonrpsee-core 0.22.5",
  "jsonrpsee-http-client",
- "jsonrpsee-types",
+ "jsonrpsee-types 0.22.5",
+]
+
+[[package]]
+name = "jsonrpsee"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b089779ad7f80768693755a031cc14a7766aba707cbe886674e3f79e9b7e47"
+dependencies = [
+ "jsonrpsee-core 0.23.2",
+ "jsonrpsee-types 0.23.2",
+ "jsonrpsee-ws-client",
 ]
 
 [[package]]
@@ -2982,14 +3056,37 @@ checksum = "4978087a58c3ab02efc5b07c5e5e2803024536106fd5506f558db172c889b3aa"
 dependencies = [
  "futures-util",
  "http 0.2.12",
- "jsonrpsee-core",
+ "jsonrpsee-core 0.22.5",
  "pin-project",
  "rustls-native-certs 0.7.0",
  "rustls-pki-types",
- "soketto",
+ "soketto 0.7.1",
  "thiserror",
  "tokio",
  "tokio-rustls 0.25.0",
+ "tokio-util",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "jsonrpsee-client-transport"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08163edd8bcc466c33d79e10f695cdc98c00d1e6ddfb95cec41b6b0279dd5432"
+dependencies = [
+ "base64 0.22.1",
+ "futures-util",
+ "http 1.1.0",
+ "jsonrpsee-core 0.23.2",
+ "pin-project",
+ "rustls 0.23.7",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
+ "soketto 0.8.0",
+ "thiserror",
+ "tokio",
+ "tokio-rustls 0.26.0",
  "tokio-util",
  "tracing",
  "url",
@@ -3007,7 +3104,29 @@ dependencies = [
  "futures-timer",
  "futures-util",
  "hyper 0.14.28",
- "jsonrpsee-types",
+ "jsonrpsee-types 0.22.5",
+ "pin-project",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
+name = "jsonrpsee-core"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79712302e737d23ca0daa178e752c9334846b08321d439fd89af9a384f8c830b"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "beef",
+ "futures-timer",
+ "futures-util",
+ "jsonrpsee-types 0.23.2",
  "pin-project",
  "rustc-hash",
  "serde",
@@ -3027,8 +3146,8 @@ dependencies = [
  "async-trait",
  "hyper 0.14.28",
  "hyper-rustls",
- "jsonrpsee-core",
- "jsonrpsee-types",
+ "jsonrpsee-core 0.22.5",
+ "jsonrpsee-types 0.22.5",
  "serde",
  "serde_json",
  "thiserror",
@@ -3049,6 +3168,32 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror",
+]
+
+[[package]]
+name = "jsonrpsee-types"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c465fbe385238e861fdc4d1c85e04ada6c1fd246161d26385c1b311724d2af"
+dependencies = [
+ "beef",
+ "http 1.1.0",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "jsonrpsee-ws-client"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c28759775f5cb2f1ea9667672d3fe2b0e701d1f4b7b67954e60afe7fd058b5e"
+dependencies = [
+ "http 1.1.0",
+ "jsonrpsee-client-transport 0.23.2",
+ "jsonrpsee-core 0.23.2",
+ "jsonrpsee-types 0.23.2",
+ "url",
 ]
 
 [[package]]
@@ -3986,9 +4131,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.82"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -4071,6 +4216,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "reconnecting-jsonrpsee-ws-client"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06fa4f17e09edfc3131636082faaec633c7baa269396b4004040bc6c52f49f65"
+dependencies = [
+ "cfg_aliases 0.2.1",
+ "finito",
+ "futures",
+ "jsonrpsee 0.23.2",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -4348,6 +4509,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebbbdb961df0ad3f2652da8f3fdc4b36122f568f968f45ad3316f26c025c677b"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.3",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rustls-native-certs"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4396,6 +4572,33 @@ name = "rustls-pki-types"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93bda3f493b9abe5b93b3e7e3ecde0df292f2bd28c0296b90586ee0055ff5123"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni",
+ "log",
+ "once_cell",
+ "rustls 0.23.7",
+ "rustls-native-certs 0.7.0",
+ "rustls-platform-verifier-android",
+ "rustls-webpki 0.102.3",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-roots",
+ "winapi",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
@@ -4462,9 +4665,9 @@ dependencies = [
 
 [[package]]
 name = "scale-bits"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "662d10dcd57b1c2a3c41c9cf68f71fb09747ada1ea932ad961aca7e2ca28315f"
+checksum = "e57b1e7f6b65ed1f04e79a85a57d755ad56d76fdf1e9bddcc9ae14f71fcdcf54"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -4488,15 +4691,15 @@ dependencies = [
 
 [[package]]
 name = "scale-decode"
-version = "0.11.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afc79ba56a1c742f5aeeed1f1801f3edf51f7e818f0a54582cac6f131364ea7b"
+checksum = "e98f3262c250d90e700bb802eb704e1f841e03331c2eb815e46516c4edbf5b27"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
  "primitive-types",
- "scale-bits 0.5.0",
- "scale-decode-derive 0.11.1",
+ "scale-bits 0.6.0",
+ "scale-decode-derive 0.13.1",
  "scale-type-resolver",
  "smallvec",
 ]
@@ -4516,9 +4719,9 @@ dependencies = [
 
 [[package]]
 name = "scale-decode-derive"
-version = "0.11.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5398fdb3c7bea3cb419bac4983aadacae93fe1a7b5f693f4ebd98c3821aad7a5"
+checksum = "9bb22f574168103cdd3133b19281639ca65ad985e24612728f727339dcaf4021"
 dependencies = [
  "darling 0.14.4",
  "proc-macro2",
@@ -4541,15 +4744,15 @@ dependencies = [
 
 [[package]]
 name = "scale-encode"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "628800925a33794fb5387781b883b5e14d130fece9af5a63613867b8de07c5c7"
+checksum = "4ba0b9c48dc0eb20c60b083c29447c0c4617cb7c4a4c9fef72aa5c5bc539e15e"
 dependencies = [
  "derive_more",
  "parity-scale-codec",
  "primitive-types",
- "scale-bits 0.5.0",
- "scale-encode-derive 0.6.0",
+ "scale-bits 0.6.0",
+ "scale-encode-derive 0.7.1",
  "scale-type-resolver",
  "smallvec",
 ]
@@ -4569,9 +4772,9 @@ dependencies = [
 
 [[package]]
 name = "scale-encode-derive"
-version = "0.6.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a304e1af7cdfbe7a24e08b012721456cc8cecdedadc14b3d10513eada63233c"
+checksum = "82ab7e60e2d9c8d47105f44527b26f04418e5e624ffc034f6b4a86c0ba19c5bf"
 dependencies = [
  "darling 0.14.4",
  "proc-macro-crate 1.3.1",
@@ -4609,9 +4812,9 @@ dependencies = [
 
 [[package]]
 name = "scale-type-resolver"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10b800069bfd43374e0f96f653e0d46882a2cb16d6d961ac43bea80f26c76843"
+checksum = "f0cded6518aa0bd6c1be2b88ac81bf7044992f0f154bfbabd5ad34f43512abcb"
 dependencies = [
  "scale-info",
  "smallvec",
@@ -4619,9 +4822,9 @@ dependencies = [
 
 [[package]]
 name = "scale-typegen"
-version = "0.2.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d470fa75e71b12b3244a4113adc4bc49891f3daba2054703cacd06256066397e"
+checksum = "498d1aecf2ea61325d4511787c115791639c0fd21ef4f8e11e49dd09eff2bbac"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4632,9 +4835,9 @@ dependencies = [
 
 [[package]]
 name = "scale-value"
-version = "0.14.1"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c07ccfee963104335c971aaf8b7b0e749be8569116322df23f1f75c4ca9e4a28"
+checksum = "5ab68da501822d2769c4c5823535f6104a6d4cd15f0d3eba3e647e725294ae22"
 dependencies = [
  "base58",
  "blake2",
@@ -4642,9 +4845,9 @@ dependencies = [
  "either",
  "frame-metadata 15.1.0",
  "parity-scale-codec",
- "scale-bits 0.5.0",
- "scale-decode 0.11.1",
- "scale-encode 0.6.0",
+ "scale-bits 0.6.0",
+ "scale-decode 0.13.1",
+ "scale-encode 0.7.1",
  "scale-info",
  "scale-type-resolver",
  "serde",
@@ -4794,6 +4997,7 @@ dependencies = [
  "core-foundation",
  "core-foundation-sys",
  "libc",
+ "num-bigint",
  "security-framework-sys",
 ]
 
@@ -4818,9 +5022,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.202"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "226b61a0d411b2ba5ff6d7f73a476ac4f8bb900373459cd00fab8512828ba395"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
 dependencies = [
  "serde_derive",
 ]
@@ -4836,9 +5040,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.202"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6048858004bcff69094cd972ed40a32500f153bd3be9f716b2eed2e8217c4838"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4937,6 +5141,17 @@ dependencies = [
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -5130,7 +5345,7 @@ dependencies = [
  "siphasher",
  "slab",
  "smallvec",
- "soketto",
+ "soketto 0.7.1",
  "twox-hash",
  "wasmi",
  "x25519-dalek",
@@ -5196,6 +5411,21 @@ dependencies = [
  "log",
  "rand",
  "sha-1",
+]
+
+[[package]]
+name = "soketto"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37468c595637c10857701c990f93a40ce0e357cedb0953d1c26c8d8027f9bb53"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures",
+ "httparse",
+ "log",
+ "rand",
+ "sha1",
 ]
 
 [[package]]
@@ -5667,33 +5897,31 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "subxt"
-version = "0.35.3"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd68bef23f4de5e513ab4c29af69053e232b098f9c87ab552d7ea153b4a1fbc5"
+checksum = "a160cba1edbf3ec4fbbeaea3f1a185f70448116a6bccc8276bb39adb3b3053bd"
 dependencies = [
  "async-trait",
- "base58",
- "blake2",
- "derivative",
+ "derive-where",
  "either",
  "frame-metadata 16.0.0",
  "futures",
  "hex",
  "impl-serde",
  "instant",
- "jsonrpsee",
+ "jsonrpsee 0.22.5",
  "parity-scale-codec",
  "primitive-types",
- "scale-bits 0.5.0",
- "scale-decode 0.11.1",
- "scale-encode 0.6.0",
+ "reconnecting-jsonrpsee-ws-client",
+ "scale-bits 0.6.0",
+ "scale-decode 0.13.1",
+ "scale-encode 0.7.1",
  "scale-info",
  "scale-value",
  "serde",
  "serde_json",
- "sp-core",
  "sp-crypto-hashing",
- "sp-runtime",
+ "subxt-core",
  "subxt-lightclient",
  "subxt-macro",
  "subxt-metadata",
@@ -5705,14 +5933,14 @@ dependencies = [
 
 [[package]]
 name = "subxt-codegen"
-version = "0.35.3"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d9e2b256b71d31a2629e44eb9cbfd944eb7d577c9e0c8e9802cc3c3943af2d9"
+checksum = "d703dca0905cc5272d7cc27a4ac5f37dcaae7671acc7fef0200057cc8c317786"
 dependencies = [
  "frame-metadata 16.0.0",
- "heck 0.4.1",
+ "heck 0.5.0",
  "hex",
- "jsonrpsee",
+ "jsonrpsee 0.22.5",
  "parity-scale-codec",
  "proc-macro2",
  "quote",
@@ -5725,10 +5953,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "subxt-lightclient"
-version = "0.35.3"
+name = "subxt-core"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d51f1ac12e3be7aafea4d037730a57da4f22f2e9c73955666081ffa2697c6f1"
+checksum = "59f41eb2e2eea6ed45649508cc735f92c27f1fcfb15229e75f8270ea73177345"
+dependencies = [
+ "base58",
+ "blake2",
+ "derive-where",
+ "frame-metadata 16.0.0",
+ "hashbrown 0.14.5",
+ "hex",
+ "impl-serde",
+ "parity-scale-codec",
+ "primitive-types",
+ "scale-bits 0.6.0",
+ "scale-decode 0.13.1",
+ "scale-encode 0.7.1",
+ "scale-info",
+ "scale-value",
+ "serde",
+ "serde_json",
+ "sp-core",
+ "sp-crypto-hashing",
+ "sp-runtime",
+ "subxt-metadata",
+ "tracing",
+]
+
+[[package]]
+name = "subxt-lightclient"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d9406fbdb9548c110803cb8afa750f8b911d51eefdf95474b11319591d225d9"
 dependencies = [
  "futures",
  "futures-util",
@@ -5743,9 +6000,9 @@ dependencies = [
 
 [[package]]
 name = "subxt-macro"
-version = "0.35.3"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98dc84d7e6a0abd7ed407cce0bf60d7d58004f699460cffb979640717d1ab506"
+checksum = "1c195f803d70687e409aba9be6c87115b5da8952cd83c4d13f2e043239818fcd"
 dependencies = [
  "darling 0.20.8",
  "parity-scale-codec",
@@ -5758,11 +6015,10 @@ dependencies = [
 
 [[package]]
 name = "subxt-metadata"
-version = "0.35.3"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc10c54028d079a9f1be65188707cd29e5ffd8d0031a2b1346a0941d57b7ab7e"
+checksum = "738be5890fdeff899bbffff4d9c0f244fe2a952fb861301b937e3aa40ebb55da"
 dependencies = [
- "derive_more",
  "frame-metadata 16.0.0",
  "hashbrown 0.14.5",
  "parity-scale-codec",
@@ -5772,13 +6028,12 @@ dependencies = [
 
 [[package]]
 name = "subxt-signer"
-version = "0.35.3"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ccb59a38fe357fab55247756174435e8626b93929864e8a498635a15e779df8"
+checksum = "f49888ae6ae90fe01b471193528eea5bd4ed52d8eecd2d13f4a2333b87388850"
 dependencies = [
  "bip39",
  "cfg-if",
- "derive_more",
  "hex",
  "hmac 0.12.1",
  "parity-scale-codec",
@@ -5789,7 +6044,7 @@ dependencies = [
  "secrecy",
  "sha2 0.10.8",
  "sp-crypto-hashing",
- "subxt",
+ "subxt-core",
  "zeroize",
 ]
 
@@ -5895,18 +6150,18 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"
-version = "1.0.60"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "579e9083ca58dd9dcf91a9923bb9054071b9ebbd800b342194c9feb0ee89fc18"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.60"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2470041c06ec3ac1ab38d0356a6119054dedaea53e12fbefc0de730a1c08524"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6014,6 +6269,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
 dependencies = [
  "rustls 0.22.4",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+dependencies = [
+ "rustls 0.23.7",
  "rustls-pki-types",
  "tokio",
 ]
@@ -6807,6 +7073,15 @@ checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd7c23921eeb1713a4e851530e9b9756e4fb0e89978582942612524cf09f01cd"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/crates/cargo-contract/Cargo.toml
+++ b/crates/cargo-contract/Cargo.toml
@@ -43,7 +43,7 @@ comfy-table = "7.1.1"
 
 # dependencies for extrinsics (deploying and calling a contract)
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-subxt = { version = "0.35.3", features = ["substrate-compat"] }
+subxt = { version = "0.37.0", features = ["substrate-compat"] }
 sp-core = "31.0.0"
 sp-weights = "30.0.0"
 hex = "0.4.3"

--- a/crates/extrinsics/Cargo.toml
+++ b/crates/extrinsics/Cargo.toml
@@ -36,7 +36,7 @@ sp-runtime = "34.0.0"
 sp-weights = "30.0.0"
 pallet-contracts-uapi = { package = "pallet-contracts-uapi-next", version = "=6.0.3", features = ["scale"] }
 scale-info = "2.11.3"
-subxt = "0.35.3"
+subxt = "0.37.0"
 hex = "0.4.3"
 derivative = "2.2.0"
 ink_metadata = "5.0.0"
@@ -49,7 +49,7 @@ regex = "1.10.4"
 predicates = "3.1.0"
 tempfile = "3.10.1"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-subxt-signer = { version = "0.35.3", features = ["subxt", "sr25519"] }
+subxt-signer = { version = "0.37.0", features = ["subxt", "sr25519"] }
 
 [features]
 integration-tests = []

--- a/crates/extrinsics/src/extrinsic_calls.rs
+++ b/crates/extrinsics/src/extrinsic_calls.rs
@@ -14,15 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::{
-    upload::Determinism,
-    WasmCode,
-};
+use crate::{upload::Determinism, WasmCode};
 use subxt::{
-    ext::{
-        codec::Compact,
-        scale_encode::EncodeAsType,
-    },
+    ext::{codec::Compact, scale_encode::EncodeAsType},
     utils::MultiAddress,
 };
 
@@ -69,8 +63,8 @@ impl<Hash> RemoveCode<Hash> {
         Self { code_hash }
     }
 
-    pub fn build(self) -> subxt::tx::Payload<Self> {
-        subxt::tx::Payload::new("Contracts", "remove_code", self)
+    pub fn build(self) -> subxt::tx::DefaultPayload<Self> {
+        subxt::tx::DefaultPayload::new("Contracts", "remove_code", self)
     }
 }
 
@@ -96,8 +90,8 @@ impl<Balance> UploadCode<Balance> {
         }
     }
 
-    pub fn build(self) -> subxt::tx::Payload<Self> {
-        subxt::tx::Payload::new("Contracts", "upload_code", self)
+    pub fn build(self) -> subxt::tx::DefaultPayload<Self> {
+        subxt::tx::DefaultPayload::new("Contracts", "upload_code", self)
     }
 }
 
@@ -133,8 +127,8 @@ impl<Balance> InstantiateWithCode<Balance> {
         }
     }
 
-    pub fn build(self) -> subxt::tx::Payload<Self> {
-        subxt::tx::Payload::new("Contracts", "instantiate_with_code", self)
+    pub fn build(self) -> subxt::tx::DefaultPayload<Self> {
+        subxt::tx::DefaultPayload::new("Contracts", "instantiate_with_code", self)
     }
 }
 
@@ -176,8 +170,8 @@ where
         }
     }
 
-    pub fn build(self) -> subxt::tx::Payload<Self> {
-        subxt::tx::Payload::new("Contracts", "instantiate", self)
+    pub fn build(self) -> subxt::tx::DefaultPayload<Self> {
+        subxt::tx::DefaultPayload::new("Contracts", "instantiate", self)
     }
 }
 
@@ -210,7 +204,7 @@ impl<AccountId, Balance> Call<AccountId, Balance> {
         }
     }
 
-    pub fn build(self) -> subxt::tx::Payload<Self> {
-        subxt::tx::Payload::new("Contracts", "call", self)
+    pub fn build(self) -> subxt::tx::DefaultPayload<Self> {
+        subxt::tx::DefaultPayload::new("Contracts", "call", self)
     }
 }

--- a/crates/extrinsics/src/extrinsic_calls.rs
+++ b/crates/extrinsics/src/extrinsic_calls.rs
@@ -14,9 +14,15 @@
 // You should have received a copy of the GNU General Public License
 // along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::{upload::Determinism, WasmCode};
+use crate::{
+    upload::Determinism, 
+    WasmCode
+};
 use subxt::{
-    ext::{codec::Compact, scale_encode::EncodeAsType},
+    ext::{
+        codec::Compact, 
+        scale_encode::EncodeAsType
+    },
     utils::MultiAddress,
 };
 

--- a/crates/extrinsics/src/lib.rs
+++ b/crates/extrinsics/src/lib.rs
@@ -40,82 +40,38 @@ mod integration_tests;
 use env_check::compare_node_env_with_contract;
 
 use anyhow::Result;
-use contract_build::{
-    CrateMetadata,
-    Verbosity,
-    DEFAULT_KEY_COL_WIDTH,
-};
-use scale::{
-    Decode,
-    Encode,
-};
+use contract_build::{CrateMetadata, Verbosity, DEFAULT_KEY_COL_WIDTH};
+use scale::{Decode, Encode};
 use subxt::{
     backend::legacy::LegacyRpcMethods,
     blocks,
-    config::{
-        DefaultExtrinsicParams,
-        DefaultExtrinsicParamsBuilder,
-        ExtrinsicParams,
-    },
-    tx,
-    Config,
-    OnlineClient,
+    config::{DefaultExtrinsicParams, DefaultExtrinsicParamsBuilder, ExtrinsicParams},
+    tx, Config, OnlineClient,
 };
 
-pub use balance::{
-    BalanceVariant,
-    TokenMetadata,
-};
-pub use call::{
-    CallCommandBuilder,
-    CallExec,
-};
+pub use balance::{BalanceVariant, TokenMetadata};
+pub use call::{CallCommandBuilder, CallExec};
 pub use contract_artifacts::ContractArtifacts;
 pub use contract_info::{
-    fetch_all_contracts,
-    fetch_contract_info,
-    fetch_wasm_code,
-    ContractInfo,
-    TrieId,
+    fetch_all_contracts, fetch_contract_info, fetch_wasm_code, ContractInfo, TrieId,
 };
 use contract_metadata::ContractMetadata;
 pub use contract_storage::{
-    ContractStorage,
-    ContractStorageCell,
-    ContractStorageLayout,
-    ContractStorageRpc,
+    ContractStorage, ContractStorageCell, ContractStorageLayout, ContractStorageRpc,
 };
 pub use contract_transcode::ContractMessageTranscoder;
-pub use error::{
-    ErrorVariant,
-    GenericError,
-};
+pub use error::{ErrorVariant, GenericError};
 pub use events::DisplayEvents;
 pub use extrinsic_opts::ExtrinsicOptsBuilder;
 pub use instantiate::{
-    Code,
-    InstantiateArgs,
-    InstantiateCommandBuilder,
-    InstantiateDryRunResult,
-    InstantiateExec,
-    InstantiateExecResult,
+    Code, InstantiateArgs, InstantiateCommandBuilder, InstantiateDryRunResult,
+    InstantiateExec, InstantiateExecResult,
 };
-pub use remove::{
-    RemoveCommandBuilder,
-    RemoveExec,
-    RemoveResult,
-};
+pub use remove::{RemoveCommandBuilder, RemoveExec, RemoveResult};
 
-pub use upload::{
-    UploadCommandBuilder,
-    UploadExec,
-    UploadResult,
-};
+pub use upload::{UploadCommandBuilder, UploadExec, UploadResult};
 
-pub use rpc::{
-    RawParams,
-    RpcRequest,
-};
+pub use rpc::{RawParams, RpcRequest};
 
 /// The Wasm code of a contract.
 #[derive(Debug, Clone)]
@@ -148,7 +104,7 @@ async fn submit_extrinsic<C, Call, Signer>(
 ) -> core::result::Result<blocks::ExtrinsicEvents<C>, subxt::Error>
 where
     C: Config,
-    Call: tx::TxPayload,
+    Call: tx::Payload,
     Signer: tx::Signer<C>,
     <C::ExtrinsicParams as ExtrinsicParams<C>>::Params:
         From<<DefaultExtrinsicParams<C> as ExtrinsicParams<C>>::Params>,
@@ -171,10 +127,7 @@ where
     // We require this because we use `substrate-contracts-node` as our development node,
     // which does not currently support finality, so we just want to wait until it is
     // included in a block.
-    use subxt::error::{
-        RpcError,
-        TransactionError,
-    };
+    use subxt::error::{RpcError, TransactionError};
     use tx::TxStatus;
 
     while let Some(status) = tx.next().await {
@@ -182,7 +135,7 @@ where
             TxStatus::InBestBlock(tx_in_block)
             | TxStatus::InFinalizedBlock(tx_in_block) => {
                 let events = tx_in_block.wait_for_success().await?;
-                return Ok(events)
+                return Ok(events);
             }
             TxStatus::Error { message } => {
                 return Err(TransactionError::Error(message).into())
@@ -264,14 +217,12 @@ where
 // Converts a Url into a String representation without excluding the default port.
 pub fn url_to_string(url: &url::Url) -> String {
     match (url.port(), url.port_or_known_default()) {
-        (None, Some(port)) => {
-            format!(
-                "{}:{port}{}",
-                &url[..url::Position::AfterHost],
-                &url[url::Position::BeforePath..]
-            )
-            .to_string()
-        }
+        (None, Some(port)) => format!(
+            "{}:{port}{}",
+            &url[..url::Position::AfterHost],
+            &url[url::Position::BeforePath..]
+        )
+        .to_string(),
         _ => url.to_string(),
     }
 }

--- a/crates/extrinsics/src/lib.rs
+++ b/crates/extrinsics/src/lib.rs
@@ -40,38 +40,80 @@ mod integration_tests;
 use env_check::compare_node_env_with_contract;
 
 use anyhow::Result;
-use contract_build::{CrateMetadata, Verbosity, DEFAULT_KEY_COL_WIDTH};
-use scale::{Decode, Encode};
+use contract_build::{
+    CrateMetadata, 
+    Verbosity, 
+    DEFAULT_KEY_COL_WIDTH
+};
+use scale::{
+    Decode, 
+    Encode
+};
 use subxt::{
     backend::legacy::LegacyRpcMethods,
     blocks,
-    config::{DefaultExtrinsicParams, DefaultExtrinsicParamsBuilder, ExtrinsicParams},
-    tx, Config, OnlineClient,
+    config::{
+        DefaultExtrinsicParams, 
+        DefaultExtrinsicParamsBuilder, 
+        ExtrinsicParams
+    },
+    tx, 
+    Config, 
+    OnlineClient,
 };
 
-pub use balance::{BalanceVariant, TokenMetadata};
-pub use call::{CallCommandBuilder, CallExec};
+pub use balance::{
+    BalanceVariant, 
+    TokenMetadata
+};
+pub use call::{
+    CallCommandBuilder, 
+    CallExec
+};
 pub use contract_artifacts::ContractArtifacts;
 pub use contract_info::{
-    fetch_all_contracts, fetch_contract_info, fetch_wasm_code, ContractInfo, TrieId,
+    fetch_all_contracts, 
+    fetch_contract_info, 
+    fetch_wasm_code, 
+    ContractInfo, 
+    TrieId,
 };
 use contract_metadata::ContractMetadata;
 pub use contract_storage::{
-    ContractStorage, ContractStorageCell, ContractStorageLayout, ContractStorageRpc,
+    ContractStorage, 
+    ContractStorageCell, 
+    ContractStorageLayout, 
+    ContractStorageRpc,
 };
 pub use contract_transcode::ContractMessageTranscoder;
-pub use error::{ErrorVariant, GenericError};
+pub use error::{
+    ErrorVariant, 
+    GenericError
+};
 pub use events::DisplayEvents;
 pub use extrinsic_opts::ExtrinsicOptsBuilder;
 pub use instantiate::{
-    Code, InstantiateArgs, InstantiateCommandBuilder, InstantiateDryRunResult,
-    InstantiateExec, InstantiateExecResult,
+    Code, 
+    InstantiateArgs, 
+    InstantiateCommandBuilder, 
+    InstantiateDryRunResult,
+    InstantiateExec, 
+    InstantiateExecResult,
 };
-pub use remove::{RemoveCommandBuilder, RemoveExec, RemoveResult};
-
-pub use upload::{UploadCommandBuilder, UploadExec, UploadResult};
-
-pub use rpc::{RawParams, RpcRequest};
+pub use remove::{
+    RemoveCommandBuilder, 
+    RemoveExec, 
+    RemoveResult
+};
+pub use upload::{
+    UploadCommandBuilder, 
+    UploadExec, 
+    UploadResult
+};
+pub use rpc::{
+    RawParams, 
+    RpcRequest
+};
 
 /// The Wasm code of a contract.
 #[derive(Debug, Clone)]
@@ -127,7 +169,10 @@ where
     // We require this because we use `substrate-contracts-node` as our development node,
     // which does not currently support finality, so we just want to wait until it is
     // included in a block.
-    use subxt::error::{RpcError, TransactionError};
+    use subxt::error::{
+        RpcError, 
+        TransactionError
+    };
     use tx::TxStatus;
 
     while let Some(status) = tx.next().await {
@@ -135,7 +180,7 @@ where
             TxStatus::InBestBlock(tx_in_block)
             | TxStatus::InFinalizedBlock(tx_in_block) => {
                 let events = tx_in_block.wait_for_success().await?;
-                return Ok(events);
+                return Ok(events)
             }
             TxStatus::Error { message } => {
                 return Err(TransactionError::Error(message).into())
@@ -217,12 +262,14 @@ where
 // Converts a Url into a String representation without excluding the default port.
 pub fn url_to_string(url: &url::Url) -> String {
     match (url.port(), url.port_or_known_default()) {
-        (None, Some(port)) => format!(
-            "{}:{port}{}",
-            &url[..url::Position::AfterHost],
-            &url[url::Position::BeforePath..]
-        )
-        .to_string(),
+        (None, Some(port)) => {
+            format!(
+                "{}:{port}{}",
+                &url[..url::Position::AfterHost],
+                &url[url::Position::BeforePath..]
+            )
+            .to_string()
+        }
         _ => url.to_string(),
     }
 }


### PR DESCRIPTION
This PR upgrades the `subxt` and `subxt-signer` library from version 0.35.3 to 0.37.0.
This upgrade is necessary because version 0.37 of `subxt` includes support for the signed extension `CheckMetadataHash`.

This solves an issue when uploading a smart contract on certain chains.
_How to Replicate the Issue:_
```
// Generate a contracts parachain
pop new parachain contracts-parachain --template contracts
cd contracts-parachain
// Run it
pop up parachain -f ./network.toml
// Generate a new smart contract
cd .. & pop new contract
// Try to upload it
cargo contract upload --suri //Alice --url ws://127.0.0.1:57869 -x
```

This will throw the error:
```
ERROR: Extrinsic params error: The chain expects a signed extension with the name CheckMetadataHash, but we did not provide one
```
This issue is resolved with this upgrade.