### PR TITLE
Fix call_with_config string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Updated the toolchain version used by `ink_linting` - [#1616](https://github.com/paritytech/cargo-contract/pull/1616)
 - Bump the version of `subxt` and `subxt-signer` - [#1722](https://github.com/use-ink/cargo-contract/pull/1722)
+- Fix a bug in `call_with_config` macro.
 
 ### Removed
 - Remove support for `V11` metadata [#1722](https://github.com/use-ink/cargo-contract/pull/1722)

--- a/crates/cargo-contract/src/cmd/config.rs
+++ b/crates/cargo-contract/src/cmd/config.rs
@@ -236,7 +236,7 @@ macro_rules! call_with_config_internal {
 #[macro_export]
 macro_rules! call_with_config {
     ($obj:tt, $function:ident, $config_name:expr) => {{
-        let config_name = format!("crate::cmd::config::{}", $config_name);
+        let config_name = format!("$crate :: cmd :: config :: {}", $config_name);
         $crate::call_with_config_internal!(
             $obj,
             $function,


### PR DESCRIPTION
## Summary
Closes #_
- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependent on the specific version of `ink` or `pallet-contracts`?
<!--- Provide a general summary of your changes -->

## Description
<!--- Describe your changes in detail -->
Hi everybody! Following the ink tutorial, I found a problem
with the `cargo contract upload` command. It returns the below error: at https://use.ink/getting-started/calling-your-contract

![image](https://github.com/user-attachments/assets/c3ab1120-f63d-4004-987f-2ce9c97950f3)

After the patch:
![image](https://github.com/user-attachments/assets/5763cbfd-2a63-4a10-8690-9196233a5bbb)

The patch is so small that I didn't bother to add a test just for it, 

## Checklist before requesting a review
- [y] My code follows the style guidelines of this project
- [y] I have added an entry to `CHANGELOG.md`
- [n/a] I have commented on my code, particularly in hard-to-understand areas
- [n] I have added tests that prove my fix is effective or that my feature works
- [n] Any dependent changes have been merged and published in downstream modules
