### PR TITLE
chore: improvements peter/feat-revive branch

### DIFF
--- a/crates/build/templates/new/_Cargo.toml
+++ b/crates/build/templates/new/_Cargo.toml
@@ -5,7 +5,8 @@ authors = ["[your_name] <[your_email]>"]
 edition = "2021"
 
 [dependencies]
-ink = { version = "5.0.0", default-features = false }
+ink = { git = "https://github.com/r0gue-io/ink", branch = "sub0", default-features = false }
+polkavm-derive = "0.11.0"
 
 [dev-dependencies]
 ink_e2e = { version = "5.0.0" }

--- a/crates/build/templates/new/lib.rs
+++ b/crates/build/templates/new/lib.rs
@@ -15,6 +15,7 @@ mod {{name}} {
     impl {{camel_name}} {
         /// Constructor that initializes the `bool` value to the given `init_value`.
         #[ink(constructor)]
+        #[ink(payable)]
         pub fn new(init_value: bool) -> Self {
             Self { value: init_value }
         }
@@ -31,12 +32,14 @@ mod {{name}} {
         /// This one flips the value of the stored `bool` from `true`
         /// to `false` and vice versa.
         #[ink(message)]
+        #[ink(payable)]
         pub fn flip(&mut self) {
             self.value = !self.value;
         }
 
         /// Simply returns the current value of our `bool`.
         #[ink(message)]
+        #[ink(payable)]
         pub fn get(&self) -> bool {
             self.value
         }

--- a/crates/extrinsics/src/events.rs
+++ b/crates/extrinsics/src/events.rs
@@ -31,6 +31,7 @@ use contract_transcode::{
 use anyhow::Result;
 use ink_env::Environment;
 use scale_info::form::PortableForm;
+use sp_core::H160;
 use std::{
     fmt::{
         Display,
@@ -309,6 +310,22 @@ impl DisplayEvents {
                                 Some(token_metadata),
                             )?
                             .to_string();
+                        }
+                    }
+                    if field.type_name == Some("H160".to_string()) {
+                        // Value is in the format: H160([bytes])
+                        // Extract the byte array between the brackets and convert it to a
+                        // hexadecimal string
+                        if let (Some(start), Some(end)) =
+                            (value.find('['), value.find(']'))
+                        {
+                            let byte_str = &value[start + 1..end];
+                            let bytes: Vec<u8> = byte_str
+                                .split(", ")
+                                .filter_map(|s| s.parse::<u8>().ok())
+                                .collect();
+                            let h160_value = H160::from_slice(&bytes);
+                            value = format!("0x{}", hex::encode(h160_value.as_bytes()));
                         }
                     }
                     let _ = writeln!(


### PR DESCRIPTION
Experimental PR for testing contracts deployed into pallet_revive 
- Updated the contract template to allow the generation of RISC-V compatible contracts using the pop new contract command.
- Address parsing event data: Improved event parsing functionality to correctly handle cases where the address type is H160. 