### PR TITLE
Fix "chain configuration not found" error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+[Unreleased]
+
+### Fixed
+- Fix "chain configuration not found" error - [#1786](https://github.com/paritytech/cargo-contract/pull/1786)
+
 ## [5.0.0-alpha]
 
 ### Changed

--- a/crates/cargo-contract/src/cmd/config.rs
+++ b/crates/cargo-contract/src/cmd/config.rs
@@ -218,9 +218,9 @@ macro_rules! call_with_config_internal {
                 stringify!($config) => $obj.$function::<$config>().await,
             )*
             _ => {
-
-                let configs = vec![$(stringify!($config)),*].iter()
-                .map(|s| s.trim_start_matches("crate::cmd::config::"))
+              let configs = vec![$(stringify!($config)),*].iter()
+                .map(|s| s.trim_start_matches("$crate::cmd::config::"))
+                .map(|s| s.replace(" ", ""))
                 .collect::<Vec<_>>()
                 .join(", ");
                 Err(ErrorVariant::Generic(

--- a/crates/cargo-contract/src/cmd/config.rs
+++ b/crates/cargo-contract/src/cmd/config.rs
@@ -254,13 +254,10 @@ macro_rules! call_with_config {
             $config_name
         );
 
-        let config_name_nonspaced = format!("$crate::cmd::config::{}", $config_name);
-        let config_name_spaced = format!("$crate :: cmd :: config :: {}", $config_name);
-
         let res_nonspaced = $crate::call_with_config_internal!(
             $obj,
             $function,
-            config_name_nonspaced.as_str(),
+            format!("$crate::cmd::config::{}", $config_name).as_str(),
             // All available chain configs need to be specified here
             $crate::cmd::config::Polkadot,
             $crate::cmd::config::Substrate,
@@ -273,7 +270,7 @@ macro_rules! call_with_config {
         $crate::call_with_config_internal!(
             $obj,
             $function,
-            config_name_spaced.as_str(),
+            format!("$crate :: cmd :: config :: {}", $config_name).as_str(),
             // All available chain configs need to be specified here
             $crate::cmd::config::Polkadot,
             $crate::cmd::config::Substrate,

--- a/crates/cargo-contract/src/cmd/config.rs
+++ b/crates/cargo-contract/src/cmd/config.rs
@@ -263,7 +263,9 @@ macro_rules! call_with_config {
             $crate::cmd::config::Substrate,
             $crate::cmd::config::Ecdsachain
         );
-        if !res_nonspaced.is_err() {return res_nonspaced}
+        if !res_nonspaced.is_err() {
+            return res_nonspaced
+        }
         $crate::call_with_config_internal!(
             $obj,
             $function,

--- a/crates/cargo-contract/src/cmd/config.rs
+++ b/crates/cargo-contract/src/cmd/config.rs
@@ -220,7 +220,7 @@ macro_rules! call_with_config_internal {
             _ => {
               let configs = vec![$(stringify!($config)),*].iter()
                 .map(|s| s.replace(" ", ""))
-                .map(|s| s.trim_start_matches("$crate::cmd::config::"))
+                .map(|s| s.trim_start_matches("$crate::cmd::config::").to_string())
                 .collect::<Vec<_>>()
                 .join(", ");
                 Err(ErrorVariant::Generic(
@@ -263,8 +263,8 @@ macro_rules! call_with_config {
             $crate::cmd::config::Substrate,
             $crate::cmd::config::Ecdsachain
         );
-
-        let res_spaced = $crate::call_with_config_internal!(
+        if !res_nonspaced.is_err() {return res_nonspaced}
+        $crate::call_with_config_internal!(
             $obj,
             $function,
             config_name_spaced.as_str(),
@@ -272,12 +272,6 @@ macro_rules! call_with_config {
             $crate::cmd::config::Polkadot,
             $crate::cmd::config::Substrate,
             $crate::cmd::config::Ecdsachain
-        );
-
-        if !res_spaced.is_err() {
-            res_nonspaced
-        } else {
-            res_spaced
-        }
+        )
     }};
 }

--- a/crates/cargo-contract/src/cmd/config.rs
+++ b/crates/cargo-contract/src/cmd/config.rs
@@ -225,7 +225,7 @@ macro_rules! call_with_config_internal {
                 .join(", ");
                 Err(ErrorVariant::Generic(
                     contract_extrinsics::GenericError::from_message(
-                        format!("Chain configuration not found, Allowed configurations: {configs}")
+                        format!("Chain configuration {} not found, allowed configurations: {configs}", $config_name)
                 )))
             },
         }

--- a/crates/cargo-contract/src/cmd/config.rs
+++ b/crates/cargo-contract/src/cmd/config.rs
@@ -250,7 +250,8 @@ macro_rules! call_with_config {
     ($obj:tt, $function:ident, $config_name:expr) => {{
         assert!(
             !format!("{}", $config_name).contains("::"),
-            "The supplied config name is not allowed to contain `::`."
+            "The supplied config name `{}` is not allowed to contain `::`.",
+            $config_name
         );
 
         let config_name_nonspaced = format!("$crate::cmd::config::{}", $config_name);

--- a/crates/cargo-contract/src/cmd/config.rs
+++ b/crates/cargo-contract/src/cmd/config.rs
@@ -219,8 +219,8 @@ macro_rules! call_with_config_internal {
             )*
             _ => {
               let configs = vec![$(stringify!($config)),*].iter()
-                .map(|s| s.trim_start_matches("$crate::cmd::config::"))
                 .map(|s| s.replace(" ", ""))
+                .map(|s| s.trim_start_matches("$crate::cmd::config::"))
                 .collect::<Vec<_>>()
                 .join(", ");
                 Err(ErrorVariant::Generic(

--- a/crates/cargo-contract/src/cmd/config.rs
+++ b/crates/cargo-contract/src/cmd/config.rs
@@ -268,6 +268,7 @@ macro_rules! call_with_config {
         if !res_nonspaced.is_err() {
             return res_nonspaced
         }
+
         $crate::call_with_config_internal!(
             $obj,
             $function,

--- a/crates/cargo-contract/src/cmd/config.rs
+++ b/crates/cargo-contract/src/cmd/config.rs
@@ -236,13 +236,15 @@ macro_rules! call_with_config_internal {
 ///
 /// # Developer Note
 ///
-/// In older Rust versions, the macro `stringify!($crate::foo)` expanded to
-/// `"$crate::foo"`. This behavior changed with https://github.com/rust-lang/rust/issues/128992,
+/// In older Rust versions the macro `stringify!($crate::foo)` expanded to
+/// `"$crate::foo"`. This behavior changed with https://github.com/rust-lang/rust/pull/125174,
 /// `stringify!` expands to `"$crate :: foo"` now. In order to support both older and
 /// newer Rust versions our macro has to handle both cases, spaced and non-spaced.
 ///
-/// Known limitation: the `$config_name:expr` has to be in the `$crate::cmd::config` crate
-/// and cannot contain another `::` sub-path.
+/// # Known Limitation
+///
+///  The `$config_name:expr` has to be in the `$crate::cmd::config` crate and cannot
+/// contain  another `::` sub-path.
 #[macro_export]
 macro_rules! call_with_config {
     ($obj:tt, $function:ident, $config_name:expr) => {{

--- a/crates/cargo-contract/src/cmd/config.rs
+++ b/crates/cargo-contract/src/cmd/config.rs
@@ -238,15 +238,18 @@ macro_rules! call_with_config_internal {
 ///
 /// In older Rust versions, the macro `stringify!($crate::foo)` expanded to
 /// `"$crate::foo"`. This behavior changed with https://github.com/rust-lang/rust/issues/128992,
-/// `stringify!` expands to `"$crate :: foo"` now. In order to support both older and newer
-/// Rust versions our macro has to handle both cases, spaced and non-spaced.
+/// `stringify!` expands to `"$crate :: foo"` now. In order to support both older and
+/// newer Rust versions our macro has to handle both cases, spaced and non-spaced.
 ///
 /// Known limitation: the `$config_name:expr` has to be in the `$crate::cmd::config` crate
 /// and cannot contain another `::` sub-path.
 #[macro_export]
 macro_rules! call_with_config {
     ($obj:tt, $function:ident, $config_name:expr) => {{
-        assert!(!format!("{}", $config_name).contains("::"), "The supplied config name is not allowed to contain `::`.");
+        assert!(
+            !format!("{}", $config_name).contains("::"),
+            "The supplied config name is not allowed to contain `::`."
+        );
 
         let config_name_nonspaced = format!("$crate::cmd::config::{}", $config_name);
         let config_name_spaced = format!("$crate :: cmd :: config :: {}", $config_name);
@@ -255,7 +258,6 @@ macro_rules! call_with_config {
             $obj,
             $function,
             config_name_nonspaced.as_str(),
-
             // All available chain configs need to be specified here
             $crate::cmd::config::Polkadot,
             $crate::cmd::config::Substrate,
@@ -266,7 +268,6 @@ macro_rules! call_with_config {
             $obj,
             $function,
             config_name_spaced.as_str(),
-
             // All available chain configs need to be specified here
             $crate::cmd::config::Polkadot,
             $crate::cmd::config::Substrate,


### PR DESCRIPTION
## Summary
Supersedes https://github.com/use-ink/cargo-contract/pull/1743.

- [n] Does it introduce breaking changes?
- [n] Is it dependent on the specific version of `ink` or `pallet-contracts`?

## Description

If `cargo-contract` is installed with newer Rust versions this error will appear when using commands that interact with a chain (`instantiate`, `upload`, `call`, etc.).

User @dhilst reported this and took this screenshot:

![image](https://github.com/user-attachments/assets/dd5d5a9c-fd7a-4a42-b02b-c970f4bd424b)

The root of the error is that `stringify!` on paths like `crate::foo` can yield either `crate :: foo` (with spaces, in newer Rust versions) or `crate::foo` (without spaces, in older Rust versions). See https://github.com/rust-lang/rust/issues/128992 for more details.

The merge of this behavior into Rust `master` occurred in https://github.com/rust-lang/rust/pull/125174 on June 12. Nightlies after that are affected and from what I can tell stable from 1.81 on (though I haven't explicitly bisected the version).

This PR makes `cargo-contract` work with either behavior.

As a follow-up I'll do a backported `4.x` patch release.