### PR TITLE
Update to latest dylint toolchain update in `ink` repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Modern releases of gcc and clang, as well as Visual Studio 2019+ should work.
 
     -   (MacOS) `brew install openssl`
     -   ```
-        export TOOLCHAIN_VERSION=nightly-2024-02-08
+        export TOOLCHAIN_VERSION=nightly-2024-09-05
         rustup install $TOOLCHAIN_VERSION
         rustup component add rust-src --toolchain $TOOLCHAIN_VERSION
         rustup run $TOOLCHAIN_VERSION cargo install cargo-dylint dylint-link

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -20,7 +20,7 @@ ARG WGET_VERSION=1.21-1+deb11u1
 ARG G_VERSION=4:10.2.1-1
 ARG MUSL_V=1.2.2-1
 # The rust version used by linter
-ARG RUST_LINTER_VERSION=nightly-2024-02-08
+ARG RUST_LINTER_VERSION=nightly-2024-09-05
 
 # metadata
 LABEL ink.use.image.vendor="Use Ink" \
@@ -105,7 +105,7 @@ RUN apt-get -y update && apt-get -y install gcc=${GCC_VERSION} g++=${G_VERSION} 
     && cargo install cargo-dylint dylint-link \
     # Check if build with linting works
     && cargo contract new test \
-    # Generate /usr/local/dylint_drivers/nightly-2024-02-08-x86_64-unknown-linux-gnu/dylint-driver bin
+    # Generate /usr/local/dylint_drivers/nightly-2024-09-05-x86_64-unknown-linux-gnu/dylint-driver bin
     && mkdir -p $DYLINT_DRIVER_PATH \
     && cd test && cargo contract build --lint --verbose --release && cd .. \
     && rm -rf test \

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -114,11 +114,11 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 pub(crate) mod linting {
     /// Toolchain used to build ink_linting:
     /// https://github.com/paritytech/ink/blob/master/linting/rust-toolchain.toml
-    pub const TOOLCHAIN_VERSION: &str = "nightly-2024-02-08";
+    pub const TOOLCHAIN_VERSION: &str = "nightly-2024-09-05";
     /// Git repository with ink_linting libraries
     pub const GIT_URL: &str = "https://github.com/use-ink/ink/";
     /// Git revision number of the linting crate
-    pub const GIT_REV: &str = "ef91c60e52eb5d3ae80fd25082bc0a9468332e36";
+    pub const GIT_REV: &str = "5ec034ca05e1239371e1d1c904d7580b375da9ca";
 }
 
 /// Arguments to use when executing `build` or `check` commands.


### PR DESCRIPTION
References https://github.com/use-ink/ink/pull/2280.