### PR TITLE
Validate externally passed Rust toolchain identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix "chain configuration not found" error - [#1786](https://github.com/paritytech/cargo-contract/pull/1786)
+- Validate externally passed Rust toolchain identifiers - [#1817](https://github.com/paritytech/cargo-contract/pull/1817)
 
 ## [5.0.0-alpha]
 

--- a/crates/cargo-contract/Cargo.toml
+++ b/crates/cargo-contract/Cargo.toml
@@ -31,6 +31,7 @@ tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 which = "7.0.0"
 colored = "2.1.0"
+regex = "1"
 serde_json = "1.0.117"
 serde = { version = "1.0.202", default-features = false, features = ["derive"] }
 url = { version = "2.5.3", features = ["serde"] }

--- a/crates/cargo-contract/src/cmd/verify.rs
+++ b/crates/cargo-contract/src/cmd/verify.rs
@@ -202,10 +202,12 @@ impl VerifyCommand {
 
             let rustc_matches = rust_toolchain == expected_rust_toolchain;
             let mismatched_rustc = format!(
-            "\nYou are trying to `verify` a contract using the `{rust_toolchain}` toolchain.\n\
-             However, the original contract was built using `{expected_rust_toolchain}`. Please\n\
-             install the correct toolchain (`rustup install {expected_rust_toolchain}`) and\n\
-             re-run the `verify` command.",);
+                "\nYou are trying to `verify` a contract using the following toolchain:\n\
+                {rust_toolchain}\n\n\
+                However, the original contract was built using this one:\n\
+                {expected_rust_toolchain}\n\n\
+                Please install the correct toolchain and re-run the `verify` command:\n\
+                rustup install {expected_rust_toolchain}");
             anyhow::ensure!(rustc_matches, mismatched_rustc.bright_yellow());
 
             let expected_cargo_contract_version = build_info.cargo_contract_version;
@@ -218,10 +220,11 @@ impl VerifyCommand {
                 cargo_contract_version == expected_cargo_contract_version;
             let mismatched_cargo_contract = format!(
                 "\nYou are trying to `verify` a contract using `cargo-contract` version \
-            `{cargo_contract_version}`.\n\
-             However, the original contract was built using `cargo-contract` version \
-             `{expected_cargo_contract_version}`.\n\
-             Please install the matching version and re-run the `verify` command.",
+                `{cargo_contract_version}`.\n\n\
+                However, the original contract was built using `cargo-contract` version \
+                `{expected_cargo_contract_version}`.\n\n\
+                Please install the matching version and re-run the `verify` command.\n\
+                cargo install --force --locked cargo-contract --version {expected_cargo_contract_version}",
             );
             anyhow::ensure!(
                 cargo_contract_matches,


### PR DESCRIPTION
How the new output formatting looks:

<img width="1278" alt="image" src="https://github.com/user-attachments/assets/b527942d-9414-4f37-9c4f-a29713c5d7f0">

I did a drive-by improvement of the output format of `cargo-contract` version mismatches:

<img width="1276" alt="image" src="https://github.com/user-attachments/assets/95f01ad7-3410-4f7a-81ef-6d2f5157743e">

