### PR TITLE
Handle case of Rust 1.79 behavior of stringify! on crate path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix "chain configuration not found" error - [#1786](https://github.com/paritytech/cargo-contract/pull/1786)
+- Fix "chain configuration not found" error (Rust 1.79) - [#1821](https://github.com/paritytech/cargo-contract/pull/1821)
 
 ## [5.0.0-alpha]
 

--- a/crates/cargo-contract/src/cmd/config.rs
+++ b/crates/cargo-contract/src/cmd/config.rs
@@ -212,13 +212,13 @@ where
 
 #[macro_export]
 macro_rules! call_with_config_internal {
-    ($obj:tt ,$function:tt, $config_name:expr, $($config:ty),*) => {
+    ($obj:tt ,$function:tt, $config_name:expr, $( ($config_str:literal, $config_obj:ty) ),*) => {
         match $config_name {
             $(
-                stringify!($config) => $obj.$function::<$config>().await,
+                $config_str => $obj.$function::<$config_obj>().await,
             )*
             _ => {
-              let configs = vec![$(stringify!($config)),*].iter()
+              let configs = vec![$($config_str),*].iter()
                 .map(|s| s.to_string())
                 .collect::<Vec<_>>()
                 .join(", ");
@@ -253,54 +253,14 @@ macro_rules! call_with_config {
             $config_name
         );
 
-        let res_nonspaced = $crate::call_with_config_internal!(
+        $crate::call_with_config_internal!(
             $obj,
             $function,
-            format!("$crate::cmd::config::{}", $config_name).as_str(),
+            $config_name,
             // All available chain configs need to be specified here
-            $crate::cmd::config::Polkadot,
-            $crate::cmd::config::Substrate,
-            $crate::cmd::config::Ecdsachain
-        );
-        if !res_nonspaced.is_err() {
-            return res_nonspaced
-        }
-
-        let res_spaced = $crate::call_with_config_internal!(
-            $obj,
-            $function,
-            format!("$crate :: cmd :: config :: {}", $config_name).as_str(),
-            // All available chain configs need to be specified here
-            $crate::cmd::config::Polkadot,
-            $crate::cmd::config::Substrate,
-            $crate::cmd::config::Ecdsachain
-        );
-        if !res_spaced.is_err() {
-            return res_spaced
-        }
-
-        let res_spaced_without_dollar = $crate::call_with_config_internal!(
-            $obj,
-            $function,
-            format!("crate :: cmd :: config :: {}", $config_name).as_str(),
-            // All available chain configs need to be specified here
-            $crate::cmd::config::Polkadot,
-            $crate::cmd::config::Substrate,
-            $crate::cmd::config::Ecdsachain
-        );
-        if !res_spaced_without_dollar.is_err() {
-            return res_spaced_without_dollar
-        }
-
-        let res_nonspaced_without_dollar = $crate::call_with_config_internal!(
-            $obj,
-            $function,
-            format!("crate::cmd::config::{}", $config_name).as_str(),
-            // All available chain configs need to be specified here
-            $crate::cmd::config::Polkadot,
-            $crate::cmd::config::Substrate,
-            $crate::cmd::config::Ecdsachain
-        );
-        res_nonspaced_without_dollar
+            ("Polkadot", $crate::cmd::config::Polkadot),
+            ("Substrate", $crate::cmd::config::Substrate),
+            ("Ecdssachain", $crate::cmd::config::Ecdsachain)
+        )
     }};
 }

--- a/crates/cargo-contract/src/cmd/config.rs
+++ b/crates/cargo-contract/src/cmd/config.rs
@@ -260,7 +260,7 @@ macro_rules! call_with_config {
             // All available chain configs need to be specified here
             ("Polkadot", $crate::cmd::config::Polkadot),
             ("Substrate", $crate::cmd::config::Substrate),
-            ("Ecdssachain", $crate::cmd::config::Ecdsachain)
+            ("Ecdsachain", $crate::cmd::config::Ecdsachain)
         )
     }};
 }


### PR DESCRIPTION
Fixes the "chain configuration not found" issue on Rust 1.79, as reported by @Lohann in https://github.com/use-ink/cargo-contract/pull/1743.

I'll backport to a 4.1.2 release.