### PR TITLE
Make extrinsic call types, upload, and events public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+[Unreleased]
+### Changed
+- Make extrinsic call types, upload, and events public - [#1873](https://github.com/use-ink/cargo-contract/pull/1873)
+
 ## [5.0.1]
 
 ### Changed

--- a/crates/extrinsics/src/extrinsic_calls.rs
+++ b/crates/extrinsics/src/extrinsic_calls.rs
@@ -77,7 +77,7 @@ impl<Hash> RemoveCode<Hash> {
 /// A raw call to `pallet-contracts`'s `upload_code`.
 #[derive(Debug, EncodeAsType)]
 #[encode_as_type(crate_path = "subxt::ext::scale_encode")]
-pub(crate) struct UploadCode<Balance> {
+pub struct UploadCode<Balance> {
     code: Vec<u8>,
     storage_deposit_limit: Option<Compact<Balance>>,
     determinism: Determinism,
@@ -104,7 +104,7 @@ impl<Balance> UploadCode<Balance> {
 /// A raw call to `pallet-contracts`'s `instantiate_with_code`.
 #[derive(Debug, EncodeAsType)]
 #[encode_as_type(crate_path = "subxt::ext::scale_encode")]
-pub(crate) struct InstantiateWithCode<Balance> {
+pub struct InstantiateWithCode<Balance> {
     #[codec(compact)]
     value: Balance,
     gas_limit: Weight,
@@ -141,7 +141,7 @@ impl<Balance> InstantiateWithCode<Balance> {
 /// A raw call to `pallet-contracts`'s `instantiate_with_code_hash`.
 #[derive(Debug, EncodeAsType)]
 #[encode_as_type(crate_path = "subxt::ext::scale_encode")]
-pub(crate) struct Instantiate<Hash, Balance>
+pub struct Instantiate<Hash, Balance>
 where
     Hash: EncodeAsType,
 {
@@ -184,7 +184,7 @@ where
 /// A raw call to `pallet-contracts`'s `call`.
 #[derive(EncodeAsType)]
 #[encode_as_type(crate_path = "subxt::ext::scale_encode")]
-pub(crate) struct Call<AccountId, Balance> {
+pub struct Call<AccountId, Balance> {
     dest: MultiAddress<AccountId, ()>,
     #[codec(compact)]
     value: Balance,

--- a/crates/extrinsics/src/lib.rs
+++ b/crates/extrinsics/src/lib.rs
@@ -21,14 +21,14 @@ mod contract_info;
 mod contract_storage;
 mod env_check;
 mod error;
-mod events;
-mod extrinsic_calls;
-mod extrinsic_opts;
+pub mod events;
+pub mod extrinsic_calls;
+pub mod extrinsic_opts;
 mod instantiate;
 pub mod pallet_contracts_primitives;
 mod remove;
 mod rpc;
-mod upload;
+pub mod upload;
 
 #[cfg(test)]
 mod contract_storage_tests;

--- a/crates/extrinsics/src/upload.rs
+++ b/crates/extrinsics/src/upload.rs
@@ -203,7 +203,7 @@ pub struct UploadResult<C: Config> {
 #[allow(dead_code)]
 #[derive(Debug, Encode, EncodeAsType)]
 #[encode_as_type(crate_path = "subxt::ext::scale_encode")]
-pub(crate) enum Determinism {
+pub enum Determinism {
     /// The execution should be deterministic and hence no indeterministic instructions
     /// are allowed.
     ///


### PR DESCRIPTION
## Summary
Closes #_
- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependent on the specific version of `ink` or `pallet-contracts`? (uses pallet-contracts)
<!--- Provide a general summary of your changes -->

## Description
These types provide useful code for managing Subxt interactions with pallet-contracts. Exposing them allows reuse in other crates, while still allowing the crates to have flexibility and manage the submission of the transaction.

## Checklist before requesting a review
- [x] I have added an entry to `CHANGELOG.md`
