### PR TITLE
Deny overflowing (and lossy) integer type cast operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Unreleased]
 
+### Added
+- Deny overflowing (and lossy) integer type cast operations - [#1895](https://github.com/use-ink/cargo-contract/pull/1895)
+
 ### Changed
 - Target `pallet-revive` instead of `pallet-contracts` - [#1851](https://github.com/use-ink/cargo-contract/pull/1851)
 

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -504,9 +504,12 @@ fn exec_cargo_clippy(crate_metadata: &CrateMetadata, verbosity: Verbosity) -> Re
         "--all-features",
         // customize clippy lints after the "--"
         "--",
-        // this is a hard error because we want to guarantee that implicit overflows
-        // never happen
+        // these are hard errors because we want to guarantee that implicit overflows
+        // and lossy integer conversions never happen
         "-Dclippy::arithmetic_side_effects",
+        "-Dclippy::cast_possible_truncation",
+        "-Dclippy::cast_possible_wrap",
+        "-Dclippy::cast_sign_loss",
     ];
     // we execute clippy with the plain manifest no temp dir required
     execute_cargo(util::cargo_cmd(

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -506,7 +506,9 @@ fn exec_cargo_clippy(crate_metadata: &CrateMetadata, verbosity: Verbosity) -> Re
         "--",
         // these are hard errors because we want to guarantee that implicit overflows
         // and lossy integer conversions never happen
+        // See https://github.com/use-ink/cargo-contract/pull/1190
         "-Dclippy::arithmetic_side_effects",
+        // See https://github.com/use-ink/cargo-contract/pull/1895
         "-Dclippy::cast_possible_truncation",
         "-Dclippy::cast_possible_wrap",
         "-Dclippy::cast_sign_loss",


### PR DESCRIPTION
## Summary
Closes #_ (N/A)
- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependent on the specific version of `ink` or `pallet-contracts`?
<!--- Provide a general summary of your changes -->
Enables clippy lints for overflowing (and lossy) integer type cast operations (i.e. `as` conversions)

## Description
<!--- Describe your changes in detail -->
[#1190 "Disallow[ed] unchecked arithmetic"](https://github.com/use-ink/cargo-contract/pull/1190), but from [this comment](https://github.com/paritytech/cargo-contract/pull/1190/files#diff-b18d9ef02a8395df7dcf8cc2d999cc16fe1fefe5b2151dfbd763f8b65e0c778dR465-R466), it looks like the actual intent was to "guarantee that implicit overflows never happen", if that's the case then like the `-C overflow-checks` for `rustc`, `-Dclippy::arithmetic_side_effects` is actually NOT sufficient.
This is because type cast operations (i.e. `as` conversions) can also cause implicit overflows/underflows (as well as other lossy conversions).

This PR enables additional clippy lints (see list below) to "guarantee that overflowing/underflowing and lossy integer operations never happen (in the local crate)". 
- https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_truncation
- https://rust-lang.github.io/rust-clippy/master/index.html#cast_possible_wrap
- https://rust-lang.github.io/rust-clippy/master/index.html#cast_sign_loss

**NOTE:** We intentionally ignore safe/lossless lints (e.g. `cast_lossless`), and lints where either the source or target type is not an integer type (e.g. `cast_precision_loss`, `char_lit_as_u8`, `as_conversions` e.t.c).

References:
https://rust-lang.github.io/rfcs/0560-integer-overflow.html#updates-since-being-accepted
https://github.com/rust-lang/rfcs/pull/1019
https://doc.rust-lang.org/reference/expressions/operator-expr.html#semantics
https://doc.rust-lang.org/reference/expressions/operator-expr.html#overflow

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have added an entry to `CHANGELOG.md`
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
