### PR TITLE
Use ink! release version in new contract template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Unreleased]
 
+### Changed
+- Use ink! release version in new contract template - [1896](https://github.com/use-ink/cargo-contract/pull/1896)
+
 ## [5.0.2]
 
 ### Changed

--- a/crates/build/src/workspace/manifest.rs
+++ b/crates/build/src/workspace/manifest.rs
@@ -274,7 +274,7 @@ impl Manifest {
     pub fn with_removed_crate_type(&mut self, crate_type: &str) -> Result<&mut Self> {
         let crate_types = self.crate_types_mut()?;
         if crate_type_exists(crate_type, crate_types) {
-            crate_types.retain(|v| v.as_str().map_or(true, |s| s != crate_type));
+            crate_types.retain(|v| v.as_str() != Some(crate_type));
         }
         Ok(self)
     }
@@ -600,9 +600,7 @@ impl PathRewrite {
 }
 
 fn crate_type_exists(crate_type: &str, crate_types: &[value::Value]) -> bool {
-    crate_types
-        .iter()
-        .any(|v| v.as_str().map_or(false, |s| s == crate_type))
+    crate_types.iter().any(|v| v.as_str() == Some(crate_type))
 }
 
 fn merge_workspace_with_crate_dependencies(

--- a/crates/build/templates/new/_Cargo.toml
+++ b/crates/build/templates/new/_Cargo.toml
@@ -5,10 +5,10 @@ authors = ["[your_name] <[your_email]>"]
 edition = "2021"
 
 [dependencies]
-ink = { version = "5.1.0", default-features = false }
+ink = { version = "5.1.1", default-features = false }
 
 [dev-dependencies]
-ink_e2e = { version = "5.1.0" }
+ink_e2e = { version = "5.1.1" }
 
 [lib]
 path = "lib.rs"


### PR DESCRIPTION
## Summary
Closes #_ (N/A)
- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependent on the specific version of `ink` or `pallet-contracts`?
<!--- Provide a general summary of your changes -->
Update `Cargo.toml` template used by new contract command (i.e. `cargo contract new <my_contract>`) to use latest crates.io version for `ink` and `ink_e2e` dependencies ~~instead of git dependencies~~.

## Description
<!--- Describe your changes in detail -->
Update `Cargo.toml` template used by new contract command (i.e. `cargo contract new <my_contract>`) to use latest crates.io version for `ink` and `ink_e2e` dependencies ~~instead of git dependencies~~.

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have added an entry to `CHANGELOG.md`
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
