### PR TITLE
Generate Solidity compatible metadata 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [Unreleased]
 
 ### Added
+- Add option to generate Solidity compatible metadata (via `cargo contract build ---metadata <ink|solidity>`) - [1930](https://github.com/use-ink/cargo-contract/pull/1930)
 - Deny overflowing (and lossy) integer type cast operations - [#1895](https://github.com/use-ink/cargo-contract/pull/1895)
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5055,7 +5055,7 @@ checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
 [[package]]
 name = "ink"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#bf546be877180ec7198a566baeee7844f7139fd0"
+source = "git+https://github.com/use-ink/ink?branch=master#39157b3b63740d51f1337925d6f9cf6678a59ae3"
 dependencies = [
  "alloy-rlp",
  "derive_more 1.0.0",
@@ -5076,7 +5076,7 @@ dependencies = [
 [[package]]
 name = "ink_allocator"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#bf546be877180ec7198a566baeee7844f7139fd0"
+source = "git+https://github.com/use-ink/ink?branch=master#39157b3b63740d51f1337925d6f9cf6678a59ae3"
 dependencies = [
  "cfg-if",
 ]
@@ -5084,7 +5084,7 @@ dependencies = [
 [[package]]
 name = "ink_codegen"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#bf546be877180ec7198a566baeee7844f7139fd0"
+source = "git+https://github.com/use-ink/ink?branch=master#39157b3b63740d51f1337925d6f9cf6678a59ae3"
 dependencies = [
  "blake2",
  "derive_more 1.0.0",
@@ -5106,7 +5106,7 @@ dependencies = [
 [[package]]
 name = "ink_engine"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#bf546be877180ec7198a566baeee7844f7139fd0"
+source = "git+https://github.com/use-ink/ink?branch=master#39157b3b63740d51f1337925d6f9cf6678a59ae3"
 dependencies = [
  "blake2",
  "derive_more 1.0.0",
@@ -5121,7 +5121,7 @@ dependencies = [
 [[package]]
 name = "ink_env"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#bf546be877180ec7198a566baeee7844f7139fd0"
+source = "git+https://github.com/use-ink/ink?branch=master#39157b3b63740d51f1337925d6f9cf6678a59ae3"
 dependencies = [
  "alloy-rlp",
  "blake2",
@@ -5154,7 +5154,7 @@ dependencies = [
 [[package]]
 name = "ink_ir"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#bf546be877180ec7198a566baeee7844f7139fd0"
+source = "git+https://github.com/use-ink/ink?branch=master#39157b3b63740d51f1337925d6f9cf6678a59ae3"
 dependencies = [
  "blake2",
  "either",
@@ -5170,7 +5170,7 @@ dependencies = [
 [[package]]
 name = "ink_macro"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#bf546be877180ec7198a566baeee7844f7139fd0"
+source = "git+https://github.com/use-ink/ink?branch=master#39157b3b63740d51f1337925d6f9cf6678a59ae3"
 dependencies = [
  "ink_codegen",
  "ink_ir",
@@ -5185,7 +5185,7 @@ dependencies = [
 [[package]]
 name = "ink_metadata"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#bf546be877180ec7198a566baeee7844f7139fd0"
+source = "git+https://github.com/use-ink/ink?branch=master#39157b3b63740d51f1337925d6f9cf6678a59ae3"
 dependencies = [
  "derive_more 1.0.0",
  "impl-serde 0.5.0",
@@ -5201,7 +5201,7 @@ dependencies = [
 [[package]]
 name = "ink_prelude"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#bf546be877180ec7198a566baeee7844f7139fd0"
+source = "git+https://github.com/use-ink/ink?branch=master#39157b3b63740d51f1337925d6f9cf6678a59ae3"
 dependencies = [
  "cfg-if",
 ]
@@ -5209,7 +5209,7 @@ dependencies = [
 [[package]]
 name = "ink_primitives"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#bf546be877180ec7198a566baeee7844f7139fd0"
+source = "git+https://github.com/use-ink/ink?branch=master#39157b3b63740d51f1337925d6f9cf6678a59ae3"
 dependencies = [
  "alloy-rlp",
  "cfg-if",
@@ -5229,7 +5229,7 @@ dependencies = [
 [[package]]
 name = "ink_storage"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#bf546be877180ec7198a566baeee7844f7139fd0"
+source = "git+https://github.com/use-ink/ink?branch=master#39157b3b63740d51f1337925d6f9cf6678a59ae3"
 dependencies = [
  "array-init",
  "cfg-if",
@@ -5247,7 +5247,7 @@ dependencies = [
 [[package]]
 name = "ink_storage_traits"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#bf546be877180ec7198a566baeee7844f7139fd0"
+source = "git+https://github.com/use-ink/ink?branch=master#39157b3b63740d51f1337925d6f9cf6678a59ae3"
 dependencies = [
  "ink_metadata",
  "ink_prelude",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "alloy-json-abi"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d62cf1b25f5a50ca2d329b0b4aeb0a0dedeaf225ad3c5099d83b1a4c4616186e"
+dependencies = [
+ "alloy-primitives 0.8.20",
+ "alloy-sol-type-parser",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "alloy-primitives"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,6 +140,33 @@ dependencies = [
  "rand",
  "ruint",
  "serde",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "alloy-primitives"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc1360603efdfba91151e623f13a4f4d3dc4af4adc1cbd90bf37c81e84db4c77"
+dependencies = [
+ "alloy-rlp",
+ "bytes",
+ "cfg-if",
+ "const-hex",
+ "derive_more 1.0.0",
+ "foldhash",
+ "hashbrown 0.15.2",
+ "indexmap 2.7.1",
+ "itoa",
+ "k256",
+ "keccak-asm",
+ "paste",
+ "proptest",
+ "rand",
+ "ruint",
+ "rustc-hash 2.1.0",
+ "serde",
+ "sha3 0.10.8",
  "tiny-keccak",
 ]
 
@@ -171,12 +210,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-sol-type-parser"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a971129d242338d92009470a2f750d3b2630bc5da00a40a94d51f5d456b5712f"
+dependencies = [
+ "serde",
+ "winnow",
+]
+
+[[package]]
 name = "alloy-sol-types"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98d7107bed88e8f09f0ddcc3335622d87bfb6821f3e0c7473329fb1cfad5e015"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.4.2",
  "alloy-sol-macro",
  "const-hex",
  "serde",
@@ -1756,6 +1805,9 @@ name = "bytes"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "camino"
@@ -2150,6 +2202,7 @@ dependencies = [
 name = "contract-build"
 version = "6.0.0-alpha"
 dependencies = [
+ "alloy-json-abi",
  "anyhow",
  "blake2",
  "bollard",
@@ -2162,11 +2215,14 @@ dependencies = [
  "heck 0.5.0",
  "hex",
  "impl-serde 0.5.0",
+ "ink_metadata",
+ "itertools 0.13.0",
  "parity-scale-codec",
  "polkavm-linker 0.18.0",
  "pretty_assertions",
  "regex",
  "rustc_version 0.4.1",
+ "scale-info",
  "semver 1.0.25",
  "serde",
  "serde_json",
@@ -4473,6 +4529,7 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
+ "serde",
 ]
 
 [[package]]
@@ -4504,6 +4561,9 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "hex-conservative"
@@ -5470,6 +5530,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7cdd4f0dc5807b9a2b25dd48a3f58e862606fe7bd47f41ecde36e97422d7e90"
 dependencies = [
  "cpufeatures",
+]
+
+[[package]]
+name = "keccak-asm"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "505d1856a39b200489082f90d897c3f07c455563880bc5952e38eabf731c83b6"
+dependencies = [
+ "digest 0.10.7",
+ "sha3-asm",
 ]
 
 [[package]]
@@ -9421,6 +9491,7 @@ dependencies = [
  "libc",
  "rand_chacha",
  "rand_core",
+ "serde",
 ]
 
 [[package]]
@@ -10690,6 +10761,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha3-asm"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28efc5e327c837aa837c59eae585fc250715ef939ac32881bcc11677cd02d46"
+dependencies = [
+ "cc",
+ "cfg-if",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11088,7 +11169,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2e6a9d00e60e3744e6b6f0c21fea6694b9c6401ac40e41340a96e561dcf1935"
 dependencies = [
- "alloy-primitives",
+ "alloy-primitives 0.4.2",
  "alloy-sol-types",
  "frame-benchmarking 38.0.0",
  "frame-support 38.2.0",

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -28,6 +28,7 @@ rustc_version = "0.4.1"
 scale = { package = "parity-scale-codec", version = "3.6.12", features = [
     "derive",
 ] }
+scale-info = "2.11.6"
 toml = "0.8.19"
 tracing = "0.1.41"
 semver = { version = "1.0.25", features = ["serde"] }
@@ -42,10 +43,13 @@ tokio = { version = "1.43.0", features = ["macros", "rt-multi-thread"] }
 tokio-stream = "0.1.17"
 bollard = "0.18.1"
 crossterm = "0.28.1"
+itertools = "0.13.0"
+alloy-json-abi = "0.8.20"
 
 polkavm-linker = "0.18.0"
 
 contract-metadata = { version = "6.0.0-alpha", path = "../metadata" }
+ink_metadata = { git = "https://github.com/use-ink/ink", branch = "master" }
 sha3 = "0.11.0-pre.4"
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/build/README.md
+++ b/crates/build/README.md
@@ -12,6 +12,7 @@ use contract_build::{
     BuildArtifacts,
     BuildMode,
     Features,
+    MetadataSpec,
     Network,
     OutputType,
     UnstableFlags,
@@ -34,6 +35,7 @@ let args = contract_build::ExecuteArgs {
     output_type: OutputType::Json,
     skip_clippy_and_linting: false,
     image: ImageVariant::Default,
+    metadata_spec: MetadataSpec::Ink,
 };
 
 contract_build::execute(args);

--- a/crates/build/src/args.rs
+++ b/crates/build/src/args.rs
@@ -26,7 +26,7 @@ use std::{
     path::Path,
 };
 
-#[derive(Default, Clone, Debug, Args)]
+#[derive(Default, Clone, Copy, Debug, Args)]
 pub struct VerbosityFlags {
     /// No output printed to stdout
     #[clap(long)]
@@ -269,6 +269,37 @@ impl Features {
                 self.features.join(",")
             };
             args.push(features);
+        }
+    }
+}
+
+/// Specification to use for contract metadata.
+#[derive(
+    Debug,
+    Default,
+    Clone,
+    Copy,
+    PartialEq,
+    Eq,
+    clap::ValueEnum,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+pub enum MetadataSpec {
+    /// ink!
+    #[clap(name = "ink")]
+    #[default]
+    Ink,
+    /// Solidity
+    #[clap(name = "solidity")]
+    Solidity,
+}
+
+impl fmt::Display for MetadataSpec {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Ink => write!(f, "ink"),
+            Self::Solidity => write!(f, "solidity"),
         }
     }
 }

--- a/crates/build/src/args.rs
+++ b/crates/build/src/args.rs
@@ -285,9 +285,11 @@ impl Features {
     serde::Serialize,
     serde::Deserialize,
 )]
+#[serde(rename_all = "lowercase")]
 pub enum MetadataSpec {
     /// ink!
     #[clap(name = "ink")]
+    #[serde(rename = "ink!")]
     #[default]
     Ink,
     /// Solidity

--- a/crates/build/src/crate_metadata.rs
+++ b/crates/build/src/crate_metadata.rs
@@ -55,6 +55,7 @@ pub struct CrateMetadata {
     pub user: Option<Map<String, Value>>,
     pub target_directory: PathBuf,
     pub target_file_path: PathBuf,
+    pub metadata_spec_path: PathBuf,
 }
 
 impl CrateMetadata {
@@ -144,6 +145,7 @@ impl CrateMetadata {
             homepage,
             user,
             target_file_path: target_directory.join(".target").into(),
+            metadata_spec_path: target_directory.join(".metadata_spec").into(),
             target_directory: target_directory.into(),
         };
         Ok(crate_metadata)

--- a/crates/build/src/docker.rs
+++ b/crates/build/src/docker.rs
@@ -290,6 +290,7 @@ async fn update_metadata(
                     &solidity_metadata_artifacts.dest_metadata,
                 )?;
                 metadata.settings.ink.image = Some(image_tag);
+
                 crate::metadata::write_solidity_metadata(
                     solidity_metadata_artifacts,
                     metadata,

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -211,7 +211,7 @@ impl BuildResult {
                 util::base_name(&metadata_result.dest_bundle).bold(),
                 match metadata_result.spec {
                     MetadataSpec::Ink => "code + metadata",
-                    MetadataSpec::Solidity => "Solidity compatible contract metadata",
+                    MetadataSpec::Solidity => "Solidity compatible metadata",
                 }
             );
             out.push_str(&bundle);

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -1068,6 +1068,7 @@ mod unit_tests {
         let raw_result = r#"{
   "dest_binary": "/path/to/contract.polkavm",
   "metadata_result": {
+    "spec": "ink!",
     "dest_metadata": "/path/to/contract.json",
     "dest_bundle": "/path/to/contract.contract"
   },
@@ -1085,6 +1086,7 @@ mod unit_tests {
         let build_result = BuildResult {
             dest_binary: Some(PathBuf::from("/path/to/contract.polkavm")),
             metadata_result: Some(MetadataArtifacts {
+                spec: MetadataSpec::Ink,
                 dest_metadata: PathBuf::from("/path/to/contract.json"),
                 dest_bundle: PathBuf::from("/path/to/contract.contract"),
             }),

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -1075,7 +1075,7 @@ mod unit_tests {
         let raw_result = r#"{
   "dest_binary": "/path/to/contract.polkavm",
   "metadata_result": {
-    "ink": {
+    "Ink": {
       "dest_metadata": "/path/to/contract.json",
       "dest_bundle": "/path/to/contract.contract"
     },

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -1078,7 +1078,7 @@ mod unit_tests {
     "Ink": {
       "dest_metadata": "/path/to/contract.json",
       "dest_bundle": "/path/to/contract.contract"
-    },
+    }
   },
   "target_directory": "/path/to/target",
   "linker_size_result": {

--- a/crates/build/src/metadata.rs
+++ b/crates/build/src/metadata.rs
@@ -204,6 +204,7 @@ pub fn execute(
                     source,
                     contract,
                     crate_metadata,
+                    None,
                 )?;
 
                 write_solidity_metadata(

--- a/crates/build/src/solidity_metadata.rs
+++ b/crates/build/src/solidity_metadata.rs
@@ -100,9 +100,9 @@ pub struct Compiler {
     /// Hash of the compiler binary which produced this output.
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "keccak256")]
-    hash: Option<CodeHash>,
+    pub hash: Option<CodeHash>,
     /// Version of the compiler.
-    version: String,
+    pub version: String,
 }
 
 /// Generated information about the contract.
@@ -114,11 +114,11 @@ pub struct Output {
     /// NatSpec developer documentation of the contract.
     /// Ref: <https://docs.soliditylang.org/en/latest/natspec-format.html#developer-documentation>
     #[serde(rename = "devdoc")]
-    dev_doc: DevDoc,
+    pub dev_doc: DevDoc,
     /// NatSpec user documentation of the contract.
     /// Ref: <https://docs.soliditylang.org/en/latest/natspec-format.html#user-documentation>
     #[serde(rename = "userdoc")]
-    user_doc: UserDoc,
+    pub user_doc: UserDoc,
 }
 
 /// Compiler settings.

--- a/crates/build/src/solidity_metadata.rs
+++ b/crates/build/src/solidity_metadata.rs
@@ -66,6 +66,15 @@ pub use self::abi::{
     write_abi,
 };
 
+/// Artifacts resulting from Solidity compatible metadata generation.
+#[derive(serde::Serialize, serde::Deserialize)]
+pub struct SolidityMetadataArtifacts {
+    /// Path to the resulting ABI file.
+    pub dest_abi: PathBuf,
+    /// Path to the resulting metadata file.
+    pub dest_metadata: PathBuf,
+}
+
 /// Solidity compatible smart contract metadata.
 ///
 /// Ref: <https://docs.soliditylang.org/en/latest/metadata.html>

--- a/crates/build/src/solidity_metadata.rs
+++ b/crates/build/src/solidity_metadata.rs
@@ -1,0 +1,292 @@
+// Copyright (C) ink! contributors.
+// This file is part of cargo-contract.
+//
+// cargo-contract is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// cargo-contract is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
+
+mod abi;
+mod natspec;
+
+use std::{
+    collections::HashMap,
+    fs::{
+        self,
+        File,
+    },
+    path::{
+        Path,
+        PathBuf,
+    },
+};
+
+use alloy_json_abi::JsonAbi;
+use anyhow::{
+    Context,
+    Result,
+};
+use cargo_metadata::TargetKind;
+use contract_metadata::{
+    CodeHash,
+    Contract,
+    Source,
+};
+use ink_metadata::InkProject;
+use serde::{
+    de,
+    ser::SerializeMap,
+    Deserialize,
+    Serialize,
+};
+
+use self::natspec::{
+    DevDoc,
+    UserDoc,
+};
+use crate::{
+    code_hash,
+    CrateMetadata,
+};
+
+// Re-exports abi utilities.
+pub use self::abi::{
+    abi_path,
+    generate_abi,
+    write_abi,
+};
+
+/// Solidity compatible smart contract metadata.
+///
+/// Ref: <https://docs.soliditylang.org/en/latest/metadata.html>
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct SolidityContractMetadata {
+    /// Details about the compiler.
+    compiler: Compiler,
+    /// Source code language
+    language: String,
+    /// Generated information about the contract.
+    pub output: Output,
+    /// Compiler settings.
+    /// Required by the spec, but very Solidity/EVM specific.
+    // TODO: (@davidsemakula) include ink! compiler settings instead?
+    #[serde(
+        serialize_with = "serialize_to_empty_map",
+        deserialize_with = "deserialize_to_unit"
+    )]
+    settings: (),
+    /// Compilation source files/source units, keys are file paths.
+    sources: HashMap<String, SourceFile>,
+    /// The version of the metadata format.
+    version: u8,
+}
+
+/// Details about the compiler.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Compiler {
+    /// Hash of the compiler binary which produced this output.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "keccak256")]
+    hash: Option<CodeHash>,
+    /// Version of the compiler.
+    version: String,
+}
+
+/// Generated information about the contract.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct Output {
+    /// ABI definition of the contract.
+    /// Ref: <https://docs.soliditylang.org/en/latest/abi-spec.html#json>
+    pub abi: JsonAbi,
+    /// NatSpec developer documentation of the contract.
+    /// Ref: <https://docs.soliditylang.org/en/latest/natspec-format.html#developer-documentation>
+    #[serde(rename = "devdoc")]
+    dev_doc: DevDoc,
+    /// NatSpec user documentation of the contract.
+    /// Ref: <https://docs.soliditylang.org/en/latest/natspec-format.html#user-documentation>
+    #[serde(rename = "userdoc")]
+    user_doc: UserDoc,
+}
+
+/// Compilation source files/source units, keys are file paths.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct SourceFile {
+    /// Contents of the source file.
+    content: String,
+    /// Hash of the source file.
+    #[serde(rename = "keccak256")]
+    hash: CodeHash,
+    /// SPDX license identifier.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    license: Option<String>,
+}
+
+impl SourceFile {
+    /// Creates a source file.
+    fn new(content: String, license: Option<String>) -> Self {
+        let hash = code_hash(content.as_bytes());
+        Self {
+            hash: CodeHash::from(hash),
+            content,
+            license,
+        }
+    }
+}
+
+/// Generates a contract metadata file compatible with the Solidity metadata specification
+/// for the ink! smart contract.
+///
+/// Ref: <https://docs.soliditylang.org/en/latest/metadata.html>
+pub fn generate_metadata(
+    ink_project: &InkProject,
+    abi: JsonAbi,
+    source: Source,
+    contract: Contract,
+    crate_metadata: &CrateMetadata,
+) -> Result<SolidityContractMetadata> {
+    let sources = source_files(crate_metadata)?;
+    let (dev_doc, user_doc) = natspec::generate_natspec(ink_project, contract)?;
+    let metadata = SolidityContractMetadata {
+        compiler: Compiler {
+            hash: None,
+            version: source.compiler.to_string(),
+        },
+        language: source.language.to_string(),
+        output: Output {
+            abi,
+            dev_doc,
+            user_doc,
+        },
+        sources,
+        settings: (),
+        version: 1,
+    };
+
+    Ok(metadata)
+}
+
+/// Get the path of the Solidity compatible contract metadata file.
+pub fn metadata_path(crate_metadata: &CrateMetadata) -> PathBuf {
+    let metadata_file = format!("{}.json", crate_metadata.contract_artifact_name);
+    crate_metadata.target_directory.join(metadata_file)
+}
+
+/// Writes a Solidity compatible metadata file.
+///
+/// Ref: <https://docs.soliditylang.org/en/latest/metadata.html>
+pub fn write_metadata<P>(metadata: &SolidityContractMetadata, path: P) -> Result<()>
+where
+    P: AsRef<Path>,
+{
+    let json = serde_json::to_string(metadata)?;
+    fs::write(path, json)?;
+
+    Ok(())
+}
+
+/// Reads the file and tries to parse it as instance of [`SolidityContractMetadata`].
+pub fn load_metadata<P>(metadata_path: P) -> Result<SolidityContractMetadata>
+where
+    P: AsRef<Path>,
+{
+    let path = metadata_path.as_ref();
+    let file = File::open(path)
+        .context(format!("Failed to open metadata file {}", path.display()))?;
+    serde_json::from_reader(file).context(format!(
+        "Failed to deserialize metadata file {}",
+        path.display()
+    ))
+}
+
+/// Returns compilation source file content, keys are relative file paths.
+fn source_files(crate_metadata: &CrateMetadata) -> Result<HashMap<String, SourceFile>> {
+    let mut source_files = HashMap::new();
+
+    // Adds `Cargo.toml` source.
+    let manifest_path = &crate_metadata.manifest_path;
+    let project_dir = manifest_path.absolute_directory()?;
+    let manifest_path_buf = PathBuf::from(manifest_path.clone());
+    let manifest_key = manifest_path_buf
+        .strip_prefix(&project_dir)
+        .unwrap_or_else(|_| &manifest_path_buf)
+        .to_string_lossy()
+        .into_owned();
+    let manifest_content = fs::read_to_string(&manifest_path_buf)?;
+    source_files.insert(
+        manifest_key,
+        SourceFile::new(
+            manifest_content,
+            crate_metadata.root_package.license.clone(),
+        ),
+    );
+
+    // Adds `lib.rs` source.
+    let lib_src_path = &crate_metadata
+        .root_package
+        .targets
+        .iter()
+        .find_map(|target| {
+            (target.kind == [TargetKind::Lib]).then_some(target.src_path.clone())
+        })
+        .context("Couldn't find `lib.rs` path")?;
+    let lib_src_content = fs::read_to_string(lib_src_path)?;
+    let lib_src_key = lib_src_path
+        .strip_prefix(&project_dir)
+        .unwrap_or_else(|_| lib_src_path)
+        .to_string();
+    source_files.insert(
+        lib_src_key,
+        SourceFile::new(lib_src_content, crate_metadata.root_package.license.clone()),
+    );
+
+    Ok(source_files)
+}
+
+/// Serializes to an empty map (regardless of input).
+pub fn serialize_to_empty_map<S>(_: &(), serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    let map = serializer.serialize_map(Some(0))?;
+    map.end()
+}
+
+/// Deserializes to a unit (expects and empty map or null).
+pub fn deserialize_to_unit<'de, D>(deserializer: D) -> Result<(), D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    struct BinOpVisitor;
+
+    impl<'de> de::Visitor<'de> for BinOpVisitor {
+        type Value = ();
+
+        fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+            write!(formatter, "an empty map or null")
+        }
+
+        fn visit_map<A>(self, _map: A) -> Result<Self::Value, A::Error>
+        where
+            A: de::MapAccess<'de>,
+        {
+            Ok(())
+        }
+
+        fn visit_none<E>(self) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(())
+        }
+    }
+
+    deserializer.deserialize_str(BinOpVisitor)
+}

--- a/crates/build/src/solidity_metadata/abi.rs
+++ b/crates/build/src/solidity_metadata/abi.rs
@@ -306,9 +306,8 @@ pub fn resolve_ty(id: u32, registry: &PortableRegistry, msg: &str) -> Result<Str
             // Unit-only enums (i.e. enums that contain only unit variants) are
             // represented as uint8.
             // Ref: <https://docs.soliditylang.org/en/latest/abi-spec.html#mapping-solidity-to-abi-types>
-            // TODO: (@davidsemakula) this actually checks if an enum is field-less. Is
-            // there any practical difference between field-less and unit-only enums in
-            // this context?
+            // NOTE: This actually checks if an enum is field-less, however, field-less
+            // and unit-only enums have an identical representation in ink! metadata.
             // Ref: <https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.fieldless>
             // Ref: <https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.unit-only>
             let contains_fields = type_def_variant

--- a/crates/build/src/solidity_metadata/abi.rs
+++ b/crates/build/src/solidity_metadata/abi.rs
@@ -1,0 +1,370 @@
+// Copyright (C) ink! contributors.
+// This file is part of cargo-contract.
+//
+// cargo-contract is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// cargo-contract is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::{
+    collections::BTreeMap,
+    fs::{
+        self,
+    },
+    path::{
+        Path,
+        PathBuf,
+    },
+};
+
+use alloy_json_abi::{
+    Constructor,
+    Event,
+    Function,
+    JsonAbi,
+};
+use anyhow::Result;
+use ink_metadata::{
+    ConstructorSpec,
+    EventSpec,
+    InkProject,
+    MessageParamSpec,
+    MessageSpec,
+    ReturnTypeSpec,
+};
+use itertools::Itertools;
+use scale_info::{
+    form::PortableForm,
+    PortableRegistry,
+    TypeDef,
+    TypeDefPrimitive,
+};
+
+use crate::CrateMetadata;
+
+/// Generates a Solidity-compatible ABI for the ink! smart contract (if possible).
+///
+/// Ref: <https://docs.soliditylang.org/en/latest/abi-spec.html#abi-json>
+pub fn generate_abi(ink_project: &InkProject) -> Result<JsonAbi> {
+    let registry = ink_project.registry();
+    let spec = ink_project.spec();
+
+    // Solidity allows only one constructor, so we arbitrarily choose the first one.
+    // FIXME: (@davidsemakula) can we make constructor selection a bit more deterministic?
+    let ctor = spec.constructors().first().ok_or_else(|| {
+        anyhow::anyhow!("Expected at least one constructor for in contract metadata")
+    })?;
+    let ctor_abi = constructor(ctor, registry)?;
+
+    let fn_abis: BTreeMap<_, _> = spec
+        .messages()
+        .iter()
+        .map(|msg| {
+            message(msg, registry).map(|fn_abi| (msg.label().clone(), vec![fn_abi]))
+        })
+        .process_results(|iter| iter.collect())?;
+
+    let event_abis: BTreeMap<_, _> = spec
+        .events()
+        .iter()
+        .map(|event_spec| {
+            event(event_spec, registry)
+                .map(|event_abi| (event_spec.label().clone(), vec![event_abi]))
+        })
+        .process_results(|iter| iter.collect())?;
+
+    Ok(JsonAbi {
+        constructor: Some(ctor_abi),
+        fallback: None,
+        receive: None,
+        functions: fn_abis,
+        events: event_abis,
+        errors: BTreeMap::new(),
+    })
+}
+
+/// Get the path of the Solidity compatible contract ABI file.
+pub fn abi_path(crate_metadata: &CrateMetadata) -> PathBuf {
+    let metadata_file = format!("{}.abi", crate_metadata.contract_artifact_name);
+    crate_metadata.target_directory.join(metadata_file)
+}
+
+/// Writes a Solidity compatible ABI file.
+///
+/// Ref: <https://docs.soliditylang.org/en/latest/abi-spec.html#abi-json>
+pub fn write_abi<P>(abi: &JsonAbi, path: P) -> Result<()>
+where
+    P: AsRef<Path>,
+{
+    let json = serde_json::to_string(abi)?;
+    fs::write(path, json)?;
+
+    Ok(())
+}
+
+/// Returns the constructor ABI representation for an ink! constructor.
+fn constructor(
+    ctor: &ConstructorSpec<PortableForm>,
+    registry: &PortableRegistry,
+) -> Result<Constructor> {
+    let params = ctor
+        .args()
+        .iter()
+        .map(|param| {
+            param_decl(param, registry, &format!("constructor `{}`", ctor.label()))
+        })
+        .process_results(|mut iter| iter.join(","))?;
+
+    // NOTE: Solidity constructors don't expose a return type.
+    let abi_str = format!(
+        "constructor({params}){}",
+        if ctor.payable { " payable" } else { "" }
+    );
+    Constructor::parse(&abi_str).map_err(|err| {
+        anyhow::anyhow!(
+            "Failed to parse abi for constructor `{}` : {err}",
+            ctor.label()
+        )
+    })
+}
+
+/// Returns the function ABI representation for an ink! message.
+fn message(
+    msg: &MessageSpec<PortableForm>,
+    registry: &PortableRegistry,
+) -> Result<Function> {
+    let name = msg.label();
+    let params = msg
+        .args()
+        .iter()
+        .map(|param| param_decl(param, registry, &format!("message `{}`", name)))
+        .process_results(|mut iter| iter.join(","))?;
+    let ret_ty = return_ty(msg.return_type(), registry, &format!("message `{}`", name))?;
+
+    let abi_str = format!(
+        "function {name}({params}) public{}{}{}",
+        // FIXME: (@davidsemakula) ink! does NOT currently enforce it's immutability
+        // claims for messages intrinsically (i.e at compile time).
+        // Ref: <https://github.com/use-ink/ink/issues/1969>
+        if msg.mutates() { "" } else { " view" },
+        if msg.payable() { " payable" } else { "" },
+        if ret_ty.is_empty() || ret_ty == "()" {
+            String::new()
+        } else {
+            format!(" returns ({ret_ty})")
+        },
+    );
+    Function::parse(&abi_str).map_err(|err| {
+        anyhow::anyhow!("Failed to parse abi for message `{}` : {err}", msg.label())
+    })
+}
+
+/// Returns the event ABI representation for an ink! event.
+fn event(
+    event_spec: &EventSpec<PortableForm>,
+    registry: &PortableRegistry,
+) -> Result<Event> {
+    let name = event_spec.label();
+    let params = event_spec
+        .args()
+        .iter()
+        .map(|param| {
+            let param_name = param.label();
+            let ty_id = param.ty().ty().id;
+            let sol_ty = resolve_ty(
+                ty_id,
+                registry,
+                &format!("arg `{param_name}` for event `{name}`"),
+            );
+            // TODO: (@davidsemakula) should we simply omit events with Solidity ABI
+            // incompatible types instead of bailing?
+            sol_ty.map(|ty| {
+                format!(
+                    "{ty}{} {param_name}",
+                    if param.indexed() { " indexed" } else { "" }
+                )
+            })
+        })
+        .process_results(|mut iter| iter.join(","))?;
+
+    // TODO: (@davidsemakula) can we represent ink!'s custom signature topics?
+    let abi_str = format!(
+        "event {name}({params}){}",
+        if event_spec.signature_topic().is_none() {
+            " anonymous"
+        } else {
+            ""
+        }
+    );
+    Event::parse(&abi_str).map_err(|err| {
+        anyhow::anyhow!(
+            "Failed to parse abi for event `{}` : {err}",
+            event_spec.label()
+        )
+    })
+}
+
+/// Returns equivalent Solidity ABI declaration (if any) for an ink! constructor or
+/// message parameter.
+fn param_decl(
+    param: &MessageParamSpec<PortableForm>,
+    registry: &PortableRegistry,
+    msg: &str,
+) -> Result<String> {
+    let name = param.label();
+    let ty_id = param.ty().ty().id;
+    let sol_ty = resolve_ty(ty_id, registry, &format!("arg `{name}` for {}", msg));
+    sol_ty.map(|ty| format!("{ty} {name}"))
+}
+
+// Returns the "user-defined" return type for an ink! message.
+//
+// **NOTE:** The return type for ink! messages is `Result<T, ink::LangError>`, however,
+// the ABI return type we're interested in is the "user-defined" `T` type.
+fn return_ty(
+    ret_ty: &ReturnTypeSpec<PortableForm>,
+    registry: &PortableRegistry,
+    msg: &str,
+) -> Result<String> {
+    let id = ret_ty.ret_type().ty().id;
+    let ty = registry
+        .resolve(id)
+        .unwrap_or_else(|| panic!("Failed to resolve return type `#{}` in {}", id, msg));
+    if let TypeDef::Variant(type_def_variant) = &ty.type_def {
+        let ok_field = type_def_variant.variants.first().and_then(|v| {
+            (v.name == "Ok" && v.fields.len() == 1).then_some(&v.fields[0])
+        });
+        if let Some(field) = ok_field {
+            return resolve_ty(field.ty.id, registry, msg);
+        }
+    }
+
+    anyhow::bail!(
+        "Expected `Result<T, ink::LangError>` return type for {}",
+        msg
+    )
+}
+
+/// Convenience macro for emitting errors for ink! types that are NOT compatible with any
+/// Solidity ABI type.
+macro_rules! incompatible_ty {
+    ($msg: expr, $ty_def: expr) => {
+        anyhow::bail!("Solidity ABI incompatible type in {}: {:?}", $msg, $ty_def)
+    };
+}
+
+/// Returns the equivalent Solidity ABI type (if any) for an ink! type (represented by the
+/// given id in ink! project metadata).
+///
+/// Ref: <https://docs.soliditylang.org/en/latest/abi-spec.html#mapping-solidity-to-abi-types>
+pub fn resolve_ty(id: u32, registry: &PortableRegistry, msg: &str) -> Result<String> {
+    let ty = registry
+        .resolve(id)
+        .unwrap_or_else(|| panic!("Failed to resolve type `#{}` in {}", id, msg));
+    match &ty.type_def {
+        TypeDef::Composite(_) => {
+            let path_segments = ty.path.segments.as_slice();
+            if path_segments == ["ink_primitives", "types", "AccountId"] {
+                Ok("address".to_string())
+            } else {
+                incompatible_ty!(msg, ty)
+            }
+        }
+        TypeDef::Variant(type_def_variant) => {
+            // Unit-only enums (i.e. enums that contain only unit variants) are
+            // represented as uint8.
+            // Ref: <https://docs.soliditylang.org/en/latest/abi-spec.html#mapping-solidity-to-abi-types>
+            // TODO: (@davidsemakula) this actually checks if an enum is field-less. Is
+            // there any practical difference between field-less and unit-only enums in
+            // this context?
+            // Ref: <https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.fieldless>
+            // Ref: <https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.unit-only>
+            let contains_fields = type_def_variant
+                .variants
+                .iter()
+                .any(|variant| !variant.fields.is_empty());
+            if !contains_fields {
+                Ok("uint8".to_string())
+            } else {
+                incompatible_ty!(msg, ty)
+            }
+        }
+        // TODO: (@davidsemakula) should `Vec<u8>` be represented as `bytes[]`? (i.e.
+        // dynamic size arrays).
+        // Ref: <https://docs.soliditylang.org/en/latest/types.html#bytes-and-string-as-arrays>
+        TypeDef::Sequence(type_def_seq) => {
+            let elem_ty_id = type_def_seq.type_param.id;
+            let elem_ty = resolve_ty(elem_ty_id, registry, msg)?;
+            Ok(format!("{elem_ty}[]"))
+        }
+        // TODO: (@davidsemakula) should `[u8; N]` arrays where `1 <= N <= 32` be
+        // represented as `bytes<N>`? (i.e. fixed-sized arrays).
+        // Ref: <https://docs.soliditylang.org/en/latest/types.html#fixed-size-byte-arrays>
+        TypeDef::Array(type_def_array) => {
+            let elem_ty_id = type_def_array.type_param.id;
+            let elem_ty = resolve_ty(elem_ty_id, registry, msg)?;
+            let len = type_def_array.len;
+            Ok(format!("{elem_ty}[{len}]"))
+        }
+        TypeDef::Tuple(type_def_tuple) => {
+            let tys = type_def_tuple
+                .fields
+                .iter()
+                .map(|field| resolve_ty(field.id, registry, msg))
+                .process_results(|mut iter| iter.join(","))?;
+            Ok(format!("({tys})"))
+        }
+        TypeDef::Primitive(type_def_primitive) => {
+            primitive_ty(type_def_primitive, msg).map(ToString::to_string)
+        }
+        TypeDef::Compact(_) | TypeDef::BitSequence(_) => {
+            incompatible_ty!(msg, ty)
+        }
+    }
+}
+
+/// Returns the equivalent Solidity elementary type (if any) for an ink! primitive type
+/// (represented by the given id in ink! project metadata).
+///
+/// Ref: <https://docs.soliditylang.org/en/latest/abi-spec.html#mapping-solidity-to-abi-types>
+fn primitive_ty(ty_def: &TypeDefPrimitive, msg: &str) -> Result<&'static str> {
+    let sol_ty = match ty_def {
+        TypeDefPrimitive::Bool => "bool",
+        // TODO: (@davidsemakula) can we represent char as a bytes4 fixed-size
+        // array and interpret it in overlong encoding?
+        // Ref: <https://en.wikipedia.org/wiki/UTF-8#overlong_encodings>
+        TypeDefPrimitive::Char => {
+            incompatible_ty!(msg, ty_def);
+        }
+        // NOTE: Rust strings are UTF-8, while solidity string literals
+        // only support ASCII characters, but Solidity also has unicode literals.
+        // However, the Solidity ABI spec uses `string` for both, and claims that `string`
+        // is a "dynamic sized unicode string assumed to be UTF-8 encoded", so presumably
+        // this is fine.
+        // Ref: <https://docs.soliditylang.org/en/latest/abi-spec.html#types>
+        // Ref: <https://docs.soliditylang.org/en/latest/types.html#string-literals-and-types>
+        // Ref: <https://docs.soliditylang.org/en/latest/types.html#unicode-literals>
+        TypeDefPrimitive::Str => "string",
+        TypeDefPrimitive::U8 => "uint8",
+        TypeDefPrimitive::U16 => "uint16",
+        TypeDefPrimitive::U32 => "uint32",
+        TypeDefPrimitive::U64 => "uint64",
+        TypeDefPrimitive::U128 => "uint128",
+        TypeDefPrimitive::U256 => "uint256",
+        TypeDefPrimitive::I8 => "int8",
+        TypeDefPrimitive::I16 => "int16",
+        TypeDefPrimitive::I32 => "int32",
+        TypeDefPrimitive::I64 => "int64",
+        TypeDefPrimitive::I128 => "int128",
+        TypeDefPrimitive::I256 => "int256",
+    };
+    Ok(sol_ty)
+}

--- a/crates/build/src/solidity_metadata/abi.rs
+++ b/crates/build/src/solidity_metadata/abi.rs
@@ -62,7 +62,7 @@ pub fn generate_abi(ink_project: &InkProject) -> Result<JsonAbi> {
     let ctors = spec.constructors();
     let ctor = ctors
         .iter()
-        .find_or_first(|ctor| *ctor.default())
+        .find_or_first(|ctor| ctor.default())
         .ok_or_else(|| {
             anyhow::anyhow!("Expected at least one constructor in contract metadata")
         })?;

--- a/crates/build/src/solidity_metadata/natspec.rs
+++ b/crates/build/src/solidity_metadata/natspec.rs
@@ -1,0 +1,262 @@
+// Copyright (C) ink! contributors.
+// This file is part of cargo-contract.
+//
+// cargo-contract is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// cargo-contract is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::collections::HashMap;
+
+use anyhow::Result;
+use contract_metadata::Contract;
+use ink_metadata::{
+    EventSpec,
+    InkProject,
+    MessageSpec,
+};
+use itertools::Itertools;
+use scale_info::{
+    form::PortableForm,
+    PortableRegistry,
+};
+use serde::{
+    Deserialize,
+    Serialize,
+};
+
+use super::abi;
+
+/// NatSpec developer documentation of the contract.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct DevDoc {
+    /// The version of the NatSpec format.
+    version: u8,
+    /// Kind of NatSpec documentation (i.e. "dev").
+    kind: NatSpecKind,
+    /// Author of the contract.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    author: Option<String>,
+    /// Describes the contract/interface.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    title: Option<String>,
+    /// Extra details for developers.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    details: Option<String>,
+    /// Storage developer documentation, keys are storage keys.
+    #[serde(rename = "stateVariables")]
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    state_variables: HashMap<String, ItemDevDoc>,
+    /// Function developer documentation, keys are canonical function signatures.
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    methods: HashMap<String, ItemDevDoc>,
+    /// Events developer documentation, keys are canonical event signatures.
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    events: HashMap<String, ItemDevDoc>,
+    /// Errors developer documentation, keys are canonical error signatures.
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    errors: HashMap<String, ItemDevDoc>,
+}
+
+/// NatSpec user documentation of the contract.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct UserDoc {
+    /// The version of the NatSpec format.
+    version: u8,
+    /// Kind of NatSpec documentation (i.e. "user").
+    kind: NatSpecKind,
+    /// Description for an end-user.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    notice: Option<String>,
+    /// Function user documentation, keys are canonical function signatures.
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    methods: HashMap<String, ItemUserDoc>,
+    /// Events user documentation, keys are canonical event signatures.
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    events: HashMap<String, ItemUserDoc>,
+    /// Errors user documentation, keys are canonical error signatures.
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    errors: HashMap<String, ItemUserDoc>,
+}
+
+/// Kind of NatSpec documentation (i.e. developer or user).
+///
+/// Ref: <https://docs.soliditylang.org/en/latest/natspec-format.html>
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+enum NatSpecKind {
+    /// Developer-focused documentation.
+    Dev,
+    /// End-user-facing documentation.
+    User,
+}
+
+/// NatSpec item description for a developer.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct ItemDevDoc {
+    /// Description for a developer.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    details: Option<String>,
+    /// Item parameter descriptions, keys are parameter names.
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    params: HashMap<String, String>,
+    /// Item return type descriptions (if any).
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    returns: HashMap<String, String>,
+}
+
+impl ItemDevDoc {
+    /// Creates a details-only developer documentation item.
+    fn details(docs: String) -> Self {
+        Self {
+            details: Some(docs),
+            params: HashMap::new(),
+            returns: HashMap::new(),
+        }
+    }
+
+    /// Creates a details and params only developer documentation item (e.g. for events).
+    fn details_and_params(docs: String, params: HashMap<String, String>) -> Self {
+        Self {
+            details: Some(docs),
+            params,
+            returns: HashMap::new(),
+        }
+    }
+}
+
+/// NatSpec item description for an end-user.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+struct ItemUserDoc {
+    /// Description for an end-user.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    notice: Option<String>,
+}
+
+/// Generates a Solidity-compatible ABI for the ink! smart contract (if possible).
+///
+/// Ref: <https://docs.soliditylang.org/en/latest/natspec-format.html>
+pub fn generate_natspec(
+    ink_project: &InkProject,
+    contract: Contract,
+) -> Result<(DevDoc, UserDoc)> {
+    let registry = ink_project.registry();
+    let spec = ink_project.spec();
+
+    let method_docs: HashMap<_, _> = spec
+        .messages()
+        .iter()
+        .filter_map(|msg| message(msg, registry))
+        .collect();
+    let event_docs: HashMap<_, _> = spec
+        .events()
+        .iter()
+        .filter_map(|event_spec| event(event_spec, registry))
+        .collect();
+
+    let dev_doc = DevDoc {
+        version: 1,
+        kind: NatSpecKind::Dev,
+        author: concat_non_empty(&contract.authors, ", "),
+        title: contract.description.clone(),
+        details: concat_non_empty(spec.docs(), "\n"),
+        // FIXME: (@davidsemakula) add storage documentation.
+        state_variables: HashMap::new(),
+        methods: method_docs,
+        events: event_docs,
+        // TODO: (@davidsemakula) add errors documentation?.
+        errors: HashMap::new(),
+    };
+    let user_doc = UserDoc {
+        version: 1,
+        kind: NatSpecKind::User,
+        notice: contract.description,
+        // TODO: (@davidsemakula) should we reuse dev docs for methods, events and
+        // errors here?.
+        methods: HashMap::new(),
+        events: HashMap::new(),
+        errors: HashMap::new(),
+    };
+
+    Ok((dev_doc, user_doc))
+}
+
+/// Returns the function signature and developer documentation (if any).
+fn message(
+    msg: &MessageSpec<PortableForm>,
+    registry: &PortableRegistry,
+) -> Option<(String, ItemDevDoc)> {
+    let name = msg.label();
+
+    // Bails if message has no docs.
+    let docs = concat_non_empty(msg.docs(), "\n")?;
+
+    // Generates the function's canonical signature.
+    // NOTE: Bails if any parameter has a Solidity ABI incompatible type.
+    let param_tys = msg
+        .args()
+        .iter()
+        .map(|param| {
+            let param_name = param.label();
+            let ty_id = param.ty().ty().id;
+            abi::resolve_ty(
+                ty_id,
+                registry,
+                &format!("arg `{param_name}` for message `{}`", name),
+            )
+        })
+        .process_results(|mut iter| iter.join(","))
+        .ok()?;
+    let fn_sig = format!("{name}({param_tys})");
+
+    // FIXME: (@davidsemakula) Add parameter documentation.
+    Some((fn_sig, ItemDevDoc::details(docs)))
+}
+
+/// Returns the function signature and developer documentation (if any).
+fn event(
+    event_spec: &EventSpec<PortableForm>,
+    registry: &PortableRegistry,
+) -> Option<(String, ItemDevDoc)> {
+    let name = event_spec.label();
+
+    // Bails if event has no docs.
+    let docs = concat_non_empty(event_spec.docs(), "\n")?;
+
+    // Generates the event's canonical signature and param docs.
+    // NOTE: Bails if any parameter has a Solidity ABI incompatible type.
+    let mut param_tys = Vec::new();
+    let mut param_docs = HashMap::new();
+    for param in event_spec.args() {
+        let param_name = param.label();
+        let ty_id = param.ty().ty().id;
+
+        let ty = abi::resolve_ty(
+            ty_id,
+            registry,
+            &format!("arg `{param_name}` for event `{}`", name),
+        )
+        .ok()?;
+        param_tys.push(ty);
+        if let Some(docs) = concat_non_empty(param.docs(), "\n") {
+            param_docs.insert(param_name.to_string(), docs);
+        }
+    }
+    let event_sig = format!("{name}({})", param_tys.join(","));
+
+    Some((event_sig, ItemDevDoc::details_and_params(docs, param_docs)))
+}
+
+/// Given a slice of strings, returns a non-empty doc string that's a concatenation of
+/// all the non-empty input strings.
+fn concat_non_empty(input: &[String], sep: &str) -> Option<String> {
+    (!input.is_empty()).then_some(input.join(sep))
+}

--- a/crates/build/src/solidity_metadata/natspec.rs
+++ b/crates/build/src/solidity_metadata/natspec.rs
@@ -39,52 +39,52 @@ use super::abi;
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct DevDoc {
     /// The version of the NatSpec format.
-    version: u8,
+    pub version: u8,
     /// Kind of NatSpec documentation (i.e. "dev").
-    kind: NatSpecKind,
+    pub kind: NatSpecKind,
     /// Author of the contract.
     #[serde(skip_serializing_if = "Option::is_none")]
-    author: Option<String>,
+    pub author: Option<String>,
     /// Describes the contract/interface.
     #[serde(skip_serializing_if = "Option::is_none")]
-    title: Option<String>,
+    pub title: Option<String>,
     /// Extra details for developers.
     #[serde(skip_serializing_if = "Option::is_none")]
-    details: Option<String>,
+    pub details: Option<String>,
     /// Storage developer documentation, keys are storage keys.
     #[serde(rename = "stateVariables")]
     #[serde(skip_serializing_if = "HashMap::is_empty")]
-    state_variables: HashMap<String, ItemDevDoc>,
+    pub state_variables: HashMap<String, ItemDevDoc>,
     /// Function developer documentation, keys are canonical function signatures.
     #[serde(skip_serializing_if = "HashMap::is_empty")]
-    methods: HashMap<String, ItemDevDoc>,
+    pub methods: HashMap<String, ItemDevDoc>,
     /// Events developer documentation, keys are canonical event signatures.
     #[serde(skip_serializing_if = "HashMap::is_empty")]
-    events: HashMap<String, ItemDevDoc>,
+    pub events: HashMap<String, ItemDevDoc>,
     /// Errors developer documentation, keys are canonical error signatures.
     #[serde(skip_serializing_if = "HashMap::is_empty")]
-    errors: HashMap<String, ItemDevDoc>,
+    pub errors: HashMap<String, ItemDevDoc>,
 }
 
 /// NatSpec user documentation of the contract.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct UserDoc {
     /// The version of the NatSpec format.
-    version: u8,
+    pub version: u8,
     /// Kind of NatSpec documentation (i.e. "user").
-    kind: NatSpecKind,
+    pub kind: NatSpecKind,
     /// Description for an end-user.
     #[serde(skip_serializing_if = "Option::is_none")]
-    notice: Option<String>,
+    pub notice: Option<String>,
     /// Function user documentation, keys are canonical function signatures.
     #[serde(skip_serializing_if = "HashMap::is_empty")]
-    methods: HashMap<String, ItemUserDoc>,
+    pub methods: HashMap<String, ItemUserDoc>,
     /// Events user documentation, keys are canonical event signatures.
     #[serde(skip_serializing_if = "HashMap::is_empty")]
-    events: HashMap<String, ItemUserDoc>,
+    pub events: HashMap<String, ItemUserDoc>,
     /// Errors user documentation, keys are canonical error signatures.
     #[serde(skip_serializing_if = "HashMap::is_empty")]
-    errors: HashMap<String, ItemUserDoc>,
+    pub errors: HashMap<String, ItemUserDoc>,
 }
 
 /// Kind of NatSpec documentation (i.e. developer or user).
@@ -92,7 +92,7 @@ pub struct UserDoc {
 /// Ref: <https://docs.soliditylang.org/en/latest/natspec-format.html>
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(rename_all = "lowercase")]
-enum NatSpecKind {
+pub enum NatSpecKind {
     /// Developer-focused documentation.
     Dev,
     /// End-user-facing documentation.
@@ -101,16 +101,16 @@ enum NatSpecKind {
 
 /// NatSpec item description for a developer.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-struct ItemDevDoc {
+pub struct ItemDevDoc {
     /// Description for a developer.
     #[serde(skip_serializing_if = "Option::is_none")]
-    details: Option<String>,
+    pub details: Option<String>,
     /// Item parameter descriptions, keys are parameter names.
     #[serde(skip_serializing_if = "HashMap::is_empty")]
-    params: HashMap<String, String>,
+    pub params: HashMap<String, String>,
     /// Item return type descriptions (if any).
     #[serde(skip_serializing_if = "HashMap::is_empty")]
-    returns: HashMap<String, String>,
+    pub returns: HashMap<String, String>,
 }
 
 impl ItemDevDoc {
@@ -135,10 +135,10 @@ impl ItemDevDoc {
 
 /// NatSpec item description for an end-user.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-struct ItemUserDoc {
+pub struct ItemUserDoc {
     /// Description for an end-user.
     #[serde(skip_serializing_if = "Option::is_none")]
-    notice: Option<String>,
+    pub notice: Option<String>,
 }
 
 /// Generates a Solidity-compatible ABI for the ink! smart contract (if possible).

--- a/crates/build/src/solidity_metadata/natspec.rs
+++ b/crates/build/src/solidity_metadata/natspec.rs
@@ -179,8 +179,8 @@ pub fn generate_natspec(
         version: 1,
         kind: NatSpecKind::User,
         notice: contract.description,
-        // TODO: (@davidsemakula) should we reuse dev docs for methods, events and
-        // errors here?.
+        // NOTE: We assume ink!/Rust comments are developer docs, so we have no way of
+        // representing the equivalent of NatSpec user docs at the moment.
         methods: HashMap::new(),
         events: HashMap::new(),
         errors: HashMap::new(),

--- a/crates/build/src/solidity_metadata/natspec.rs
+++ b/crates/build/src/solidity_metadata/natspec.rs
@@ -179,7 +179,7 @@ pub fn generate_natspec(
         version: 1,
         kind: NatSpecKind::User,
         notice: contract.description,
-        // NOTE: We assume ink!/Rust comments are developer docs, so we have no way of
+        // NOTE: We assume ink!/Rust doc comments are developer docs, so we have no way of
         // representing the equivalent of NatSpec user docs at the moment.
         methods: HashMap::new(),
         events: HashMap::new(),
@@ -201,6 +201,9 @@ fn message(
 
     // Generates the function's canonical signature.
     // NOTE: Bails if any parameter has a Solidity ABI incompatible type.
+    // NOTE: Rust doesn't currently support doc comments (i.e. rustdoc) for function
+    // parameters.
+    // Ref: <https://doc.rust-lang.org/reference/items/functions.html#attributes-on-function-parameters>
     let param_tys = msg
         .args()
         .iter()
@@ -217,7 +220,6 @@ fn message(
         .ok()?;
     let fn_sig = format!("{name}({param_tys})");
 
-    // FIXME: (@davidsemakula) Add parameter documentation.
     Some((fn_sig, ItemDevDoc::details(docs)))
 }
 

--- a/crates/build/src/tests.rs
+++ b/crates/build/src/tests.rs
@@ -549,7 +549,17 @@ fn generates_solidity_metadata(manifest_path: &ManifestPath) -> Result<()> {
     assert_eq!(kind, &Value::String("user".to_string()));
 
     let settings = metadata_json.get("settings").expect("settings not found");
-    assert_eq!(settings, &Value::Object(Map::new()));
+    let ink_build_info = settings.get("ink").expect("settings.ink not found");
+    let build_mode = ink_build_info
+        .get("build_mode")
+        .expect("settings.ink.build_mode not found");
+    assert_eq!(build_mode, &Value::String("Debug".to_string()));
+    ink_build_info
+        .get("cargo_contract_version")
+        .expect("settings.ink.cargo_contract_version not found");
+    ink_build_info
+        .get("rust_toolchain")
+        .expect("settings.ink.rust_toolchain not found");
 
     let sources = metadata_json
         .get("sources")

--- a/crates/build/src/tests.rs
+++ b/crates/build/src/tests.rs
@@ -29,6 +29,7 @@ use anyhow::Result;
 use contract_metadata::*;
 use serde_json::{
     Map,
+    Number,
     Value,
 };
 use std::{
@@ -74,6 +75,7 @@ build_tests!(
     building_contract_with_build_rs_must_work,
     missing_linting_toolchain_installation_must_be_detected,
     generates_metadata,
+    generates_solidity_metadata,
     unchanged_contract_skips_optimization_and_metadata_steps,
     unchanged_contract_no_metadata_artifacts_generates_metadata
 );
@@ -449,6 +451,121 @@ fn generates_metadata(manifest_path: &ManifestPath) -> Result<()> {
     assert_eq!("http://homepage.com/", homepage.as_str().unwrap());
     assert_eq!("Apache-2.0", license.as_str().unwrap());
     assert_eq!(&expected_user_metadata, user.as_object().unwrap());
+
+    Ok(())
+}
+
+fn generates_solidity_metadata(manifest_path: &ManifestPath) -> Result<()> {
+    // add optional metadata fields
+    let mut test_manifest = TestContractManifest::new(manifest_path.clone())?;
+    test_manifest.add_package_value("description", "contract description".into())?;
+    test_manifest
+        .add_package_value("documentation", "http://documentation.com".into())?;
+    test_manifest.add_package_value("repository", "http://repository.com".into())?;
+    test_manifest.add_package_value("homepage", "http://homepage.com".into())?;
+    test_manifest.add_package_value("license", "Apache-2.0".into())?;
+    test_manifest.write()?;
+
+    let crate_metadata = CrateMetadata::collect(manifest_path)?;
+
+    // usually this file will be produced by a previous build step
+    let final_contract_binary_path = &crate_metadata.dest_binary;
+    fs::create_dir_all(final_contract_binary_path.parent().unwrap()).unwrap();
+    fs::write(final_contract_binary_path, "TEST FINAL BINARY").unwrap();
+
+    let mut args = ExecuteArgs {
+        extra_lints: false,
+        metadata_spec: crate::MetadataSpec::Solidity,
+        ..Default::default()
+    };
+    args.manifest_path = manifest_path.clone();
+
+    let build_result = crate::execute(args)?;
+    let metadata_result = build_result
+        .metadata_result
+        .expect("Metadata should be generated");
+
+    let dest_abi = metadata_result.dest_metadata;
+    assert_eq!(dest_abi.extension().unwrap(), "abi");
+    assert!(
+        dest_abi.exists(),
+        "Missing ABI file '{}'",
+        dest_abi.display()
+    );
+
+    let dest_bundle = metadata_result.dest_bundle;
+    assert_eq!(dest_bundle.extension().unwrap(), "json");
+    assert!(
+        dest_bundle.exists(),
+        "Missing metadata file '{}'",
+        dest_bundle.display()
+    );
+
+    let abi_json: Vec<Value> = serde_json::from_slice(&fs::read(&dest_abi)?)?;
+    let metadata_json: Map<String, Value> =
+        serde_json::from_slice(&fs::read(&dest_bundle)?)?;
+
+    let compiler = metadata_json.get("compiler").expect("compiler not found");
+    let compiler_version = compiler.get("version").expect("compiler.version not found");
+    let expected_rustc_version =
+        semver::Version::parse(&rustc_version::version()?.to_string())?;
+    let expected_compiler =
+        SourceCompiler::new(Compiler::RustC, expected_rustc_version).to_string();
+    assert_eq!(expected_compiler, compiler_version.as_str().unwrap());
+
+    let language = metadata_json.get("language").expect("language not found");
+    let expected_language =
+        SourceLanguage::new(Language::Ink, crate_metadata.ink_version).to_string();
+    assert_eq!(expected_language, language.as_str().unwrap());
+
+    let output = metadata_json.get("output").expect("output not found");
+    let abi = output.get("abi").expect("output.abi not found");
+    assert_eq!(abi, &Value::Array(abi_json));
+
+    let devdoc = output.get("devdoc").expect("output.devdoc not found");
+    let version = devdoc
+        .get("version")
+        .expect("output.devdoc.version not found");
+    assert_eq!(version, &Value::Number(Number::from_u128(1).unwrap()));
+    let kind = devdoc.get("kind").expect("output.devdoc.kind not found");
+    assert_eq!(kind, &Value::String("dev".to_string()));
+    let author = devdoc
+        .get("author")
+        .expect("output.devdoc.author not found")
+        .as_str()
+        .expect("output.devdoc.author is a string");
+    assert_eq!(crate_metadata.root_package.authors.join(", "), author);
+    let title = devdoc
+        .get("title")
+        .expect("output.devdoc.description not found");
+    assert_eq!("contract description", title.as_str().unwrap());
+
+    let userdoc = output.get("userdoc").expect("output.userdoc not found");
+    let version = userdoc
+        .get("version")
+        .expect("output.userdoc.version not found");
+    assert_eq!(version, &Value::Number(Number::from_u128(1).unwrap()));
+    let kind = userdoc.get("kind").expect("output.userdoc.kind not found");
+    assert_eq!(kind, &Value::String("user".to_string()));
+
+    let settings = metadata_json.get("settings").expect("settings not found");
+    assert_eq!(settings, &Value::Object(Map::new()));
+
+    let sources = metadata_json
+        .get("sources")
+        .expect("sources not found")
+        .as_object()
+        .expect("sources is an object");
+    for (src_path, contents) in sources {
+        assert!(src_path.ends_with("Cargo.toml") || src_path.ends_with("lib.rs"));
+        let license = contents
+            .get("license")
+            .expect("sources[].license not found");
+        assert_eq!(license, &Value::String("Apache-2.0".to_string()));
+    }
+
+    let version = metadata_json.get("version").expect("version not found");
+    assert_eq!(version, &Value::Number(Number::from_u128(1).unwrap()));
 
     Ok(())
 }

--- a/crates/build/templates/generate-metadata/main.rs
+++ b/crates/build/templates/generate-metadata/main.rs
@@ -1,7 +1,7 @@
 extern crate contract;
 
 extern "Rust" {
-    // Note: The ink! metdata codegen generates an implementation for this function,
+    // Note: The ink! metadata codegen generates an implementation for this function,
     // which is what we end up linking to here.
     fn __ink_generate_metadata() -> ink::metadata::InkProject;
 }

--- a/crates/cargo-contract/src/cmd/build.rs
+++ b/crates/cargo-contract/src/cmd/build.rs
@@ -23,6 +23,7 @@ use contract_build::{
     Features,
     ImageVariant,
     ManifestPath,
+    MetadataSpec,
     Network,
     OutputType,
     UnstableFlags,
@@ -98,6 +99,9 @@ pub struct BuildCommand {
     /// Specify a custom image for the verifiable build
     #[clap(long, default_value = None)]
     image: Option<String>,
+    /// Which specification to use for contract metadata.
+    #[clap(long, default_value = "ink")]
+    metadata: MetadataSpec,
 }
 
 impl BuildCommand {
@@ -148,6 +152,7 @@ impl BuildCommand {
             output_type,
             skip_clippy_and_linting: self.skip_clippy_and_linting,
             image,
+            metadata_spec: self.metadata,
         };
         contract_build::execute(args)
     }
@@ -181,6 +186,7 @@ impl CheckCommand {
             output_type: OutputType::default(),
             skip_clippy_and_linting: false,
             image: ImageVariant::Default,
+            metadata_spec: Default::default(),
         };
 
         contract_build::execute(args)

--- a/crates/cargo-contract/src/cmd/verify.rs
+++ b/crates/cargo-contract/src/cmd/verify.rs
@@ -30,6 +30,7 @@ use contract_build::{
     ExecuteArgs,
     ImageVariant,
     ManifestPath,
+    MetadataArtifacts,
     Verbosity,
     VerbosityFlags,
 };
@@ -261,7 +262,9 @@ impl VerifyCommand {
         )
         .expect("decoding the `source.polkavm` hex failed");
         let reference_code_hash = CodeHash(code_hash(&reference_polkavm_blob));
-        let built_contract_path = if let Some(m) = build_result.metadata_result {
+        let built_contract_path = if let Some(MetadataArtifacts::Ink(m)) =
+            build_result.metadata_result
+        {
             m
         } else {
             // Since we're building the contract ourselves this should always be

--- a/crates/metadata/src/lib.rs
+++ b/crates/metadata/src/lib.rs
@@ -619,7 +619,7 @@ impl ContractBuilder {
         self
     }
 
-    /// Finalize construction of the [`ContractMetadata`].
+    /// Finalize construction of the [`Contract`] metadata.
     ///
     /// Returns an `Err` if any required fields missing.
     pub fn build(&self) -> Result<Contract, String> {


### PR DESCRIPTION
## Summary
Closes #1070 
Also closes https://github.com/use-ink/ink-alliance/issues/13
- [y] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependent on the specific version of `ink` or `pallet-contracts`?
<!--- Provide a general summary of your changes -->
Adds option to generate Solidity compatible metadata files

## Description
<!--- Describe your changes in detail -->

- Adds a CLI arg `cargo contract build --metadata <ink|solidity>` for choosing the specification to use for metadata generation
- Adds ability to generate Solidity compatible [ABI](https://docs.soliditylang.org/en/latest/abi-spec.html#json) and [metadata](https://docs.soliditylang.org/en/latest/metadata.html) files (i.e. `<artifact_name>.abi` and `<artifact_name>.json`)

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have added an entry to `CHANGELOG.md`
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
