### PR TITLE
Revert me: Force `Lto::Off`

### DIFF
--- a/crates/build/src/workspace/profile.rs
+++ b/crates/build/src/workspace/profile.rs
@@ -34,7 +34,9 @@ impl Profile {
     pub fn default_contract_release() -> Profile {
         Profile {
             opt_level: Some(OptLevel::Z),
-            lto: Some(Lto::Fat),
+            // todo change back to `Lto::Fat` once bug in `polkavm` has been fixed.
+            // currently `Lto::Fat` results in the `contract-transfer` e2e tests to fail.
+            lto: Some(Lto::Off),
             codegen_units: Some(1),
             panic: Some(PanicStrategy::Abort),
         }


### PR DESCRIPTION
There's a bunch of bugs in `polkavm` currently. We should revert this commit once some of those are fixed and see if we can bring `Lto::Fat` back.