### PR TITLE
chore: update dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5200,7 +5200,7 @@ checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
 [[package]]
 name = "ink"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=alex/update-dependencies#726bd25b4499aba8c97cd623855bbe38d4940e72"
+source = "git+https://github.com/use-ink/ink?branch=master#b7e4089869ae055ebd17958e56eefe679b52daea"
 dependencies = [
  "const_format",
  "deranged",
@@ -5224,7 +5224,7 @@ dependencies = [
 [[package]]
 name = "ink_allocator"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=alex/update-dependencies#726bd25b4499aba8c97cd623855bbe38d4940e72"
+source = "git+https://github.com/use-ink/ink?branch=master#b7e4089869ae055ebd17958e56eefe679b52daea"
 dependencies = [
  "cfg-if",
 ]
@@ -5232,7 +5232,7 @@ dependencies = [
 [[package]]
 name = "ink_codegen"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=alex/update-dependencies#726bd25b4499aba8c97cd623855bbe38d4940e72"
+source = "git+https://github.com/use-ink/ink?branch=master#b7e4089869ae055ebd17958e56eefe679b52daea"
 dependencies = [
  "blake2",
  "derive_more 2.0.1",
@@ -5254,7 +5254,7 @@ dependencies = [
 [[package]]
 name = "ink_engine"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=alex/update-dependencies#726bd25b4499aba8c97cd623855bbe38d4940e72"
+source = "git+https://github.com/use-ink/ink?branch=master#b7e4089869ae055ebd17958e56eefe679b52daea"
 dependencies = [
  "blake2",
  "derive_more 2.0.1",
@@ -5271,7 +5271,7 @@ dependencies = [
 [[package]]
 name = "ink_env"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=alex/update-dependencies#726bd25b4499aba8c97cd623855bbe38d4940e72"
+source = "git+https://github.com/use-ink/ink?branch=master#b7e4089869ae055ebd17958e56eefe679b52daea"
 dependencies = [
  "blake2",
  "cfg-if",
@@ -5305,7 +5305,7 @@ dependencies = [
 [[package]]
 name = "ink_ir"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=alex/update-dependencies#726bd25b4499aba8c97cd623855bbe38d4940e72"
+source = "git+https://github.com/use-ink/ink?branch=master#b7e4089869ae055ebd17958e56eefe679b52daea"
 dependencies = [
  "blake2",
  "either",
@@ -5321,7 +5321,7 @@ dependencies = [
 [[package]]
 name = "ink_macro"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=alex/update-dependencies#726bd25b4499aba8c97cd623855bbe38d4940e72"
+source = "git+https://github.com/use-ink/ink?branch=master#b7e4089869ae055ebd17958e56eefe679b52daea"
 dependencies = [
  "ink_codegen",
  "ink_ir",
@@ -5336,7 +5336,7 @@ dependencies = [
 [[package]]
 name = "ink_metadata"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=alex/update-dependencies#726bd25b4499aba8c97cd623855bbe38d4940e72"
+source = "git+https://github.com/use-ink/ink?branch=master#b7e4089869ae055ebd17958e56eefe679b52daea"
 dependencies = [
  "derive_more 2.0.1",
  "impl-serde 0.5.0",
@@ -5352,7 +5352,7 @@ dependencies = [
 [[package]]
 name = "ink_prelude"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=alex/update-dependencies#726bd25b4499aba8c97cd623855bbe38d4940e72"
+source = "git+https://github.com/use-ink/ink?branch=master#b7e4089869ae055ebd17958e56eefe679b52daea"
 dependencies = [
  "cfg-if",
 ]
@@ -5360,7 +5360,7 @@ dependencies = [
 [[package]]
 name = "ink_primitives"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=alex/update-dependencies#726bd25b4499aba8c97cd623855bbe38d4940e72"
+source = "git+https://github.com/use-ink/ink?branch=master#b7e4089869ae055ebd17958e56eefe679b52daea"
 dependencies = [
  "alloy-sol-types 1.0.0",
  "cfg-if",
@@ -5387,7 +5387,7 @@ dependencies = [
 [[package]]
 name = "ink_storage"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=alex/update-dependencies#726bd25b4499aba8c97cd623855bbe38d4940e72"
+source = "git+https://github.com/use-ink/ink?branch=master#b7e4089869ae055ebd17958e56eefe679b52daea"
 dependencies = [
  "array-init",
  "cfg-if",
@@ -5405,7 +5405,7 @@ dependencies = [
 [[package]]
 name = "ink_storage_traits"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=alex/update-dependencies#726bd25b4499aba8c97cd623855bbe38d4940e72"
+source = "git+https://github.com/use-ink/ink?branch=master#b7e4089869ae055ebd17958e56eefe679b52daea"
 dependencies = [
  "ink_metadata",
  "ink_prelude",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,7 +118,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d8bcce99ad10fe02640cfaec1c6bc809b837c783c1d52906aa5af66e2a196f6"
 dependencies = [
  "alloy-dyn-abi",
- "alloy-json-abi",
+ "alloy-json-abi 0.8.25",
  "alloy-primitives 0.8.25",
  "alloy-rlp",
  "alloy-sol-types 0.8.25",
@@ -130,9 +130,9 @@ version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb8e762aefd39a397ff485bc86df673465c4ad3ec8819cc60833a8a3ba5cdc87"
 dependencies = [
- "alloy-json-abi",
+ "alloy-json-abi 0.8.25",
  "alloy-primitives 0.8.25",
- "alloy-sol-type-parser",
+ "alloy-sol-type-parser 0.8.25",
  "alloy-sol-types 0.8.25",
  "const-hex",
  "itoa",
@@ -148,7 +148,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe6beff64ad0aa6ad1019a3db26fef565aefeb011736150ab73ed3366c3cfd1b"
 dependencies = [
  "alloy-primitives 0.8.25",
- "alloy-sol-type-parser",
+ "alloy-sol-type-parser 0.8.25",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-json-abi"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5189fa9a8797e92396bc4b4454c5f2073a4945f7c2b366af9af60f9536558f7a"
+dependencies = [
+ "alloy-primitives 1.0.0",
+ "alloy-sol-type-parser 1.0.0",
  "serde",
  "serde_json",
 ]
@@ -201,6 +213,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-primitives"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70b98b99c1dcfbe74d7f0b31433ff215e7d1555e367d90e62db904f3c9d4ff53"
+dependencies = [
+ "alloy-rlp",
+ "bytes",
+ "cfg-if",
+ "const-hex",
+ "derive_more 2.0.1",
+ "foldhash",
+ "hashbrown 0.15.2",
+ "indexmap 2.8.0",
+ "itoa",
+ "k256",
+ "keccak-asm",
+ "paste",
+ "proptest",
+ "rand 0.9.0",
+ "ruint",
+ "rustc-hash 2.1.1",
+ "serde",
+ "sha3",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "alloy-rlp"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,8 +272,22 @@ version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e10ae8e9a91d328ae954c22542415303919aabe976fe7a92eb06db1b68fd59f2"
 dependencies = [
- "alloy-sol-macro-expander",
- "alloy-sol-macro-input",
+ "alloy-sol-macro-expander 0.8.25",
+ "alloy-sol-macro-input 0.8.25",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "alloy-sol-macro"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60fcfa26956bcb22f66ab13407115197f26ef23abca5b48d39a1946897382d74"
+dependencies = [
+ "alloy-sol-macro-expander 1.0.0",
+ "alloy-sol-macro-input 1.0.0",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
@@ -247,7 +300,7 @@ version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83ad5da86c127751bc607c174d6c9fe9b85ef0889a9ca0c641735d77d4f98f26"
 dependencies = [
- "alloy-sol-macro-input",
+ "alloy-sol-macro-input 0.8.25",
  "const-hex",
  "heck 0.5.0",
  "indexmap 2.8.0",
@@ -256,6 +309,24 @@ dependencies = [
  "quote",
  "syn 2.0.100",
  "syn-solidity 0.8.25",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "alloy-sol-macro-expander"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72a9b402f0013f1ff8c24066eeafc2207a8e52810a2b18b77776ce7fead5af41"
+dependencies = [
+ "alloy-sol-macro-input 1.0.0",
+ "const-hex",
+ "heck 0.5.0",
+ "indexmap 2.8.0",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+ "syn-solidity 1.0.0",
  "tiny-keccak",
 ]
 
@@ -276,10 +347,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-sol-macro-input"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d02d61741337bb6b3f4899c2e3173fe17ffa2810e143d3b28acd953197c8dd79"
+dependencies = [
+ "const-hex",
+ "dunce",
+ "heck 0.5.0",
+ "macro-string",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+ "syn-solidity 1.0.0",
+]
+
+[[package]]
 name = "alloy-sol-type-parser"
 version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d162f8524adfdfb0e4bd0505c734c985f3e2474eb022af32eef0d52a4f3935c"
+dependencies = [
+ "serde",
+ "winnow",
+]
+
+[[package]]
+name = "alloy-sol-type-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2b5f5f9f561c29f78ea521ebe2e5ac1633f1b1442dae582f68ecd57c6350042"
 dependencies = [
  "serde",
  "winnow",
@@ -303,9 +400,22 @@ version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d43d5e60466a440230c07761aa67671d4719d46f43be8ea6e7ed334d8db4a9ab"
 dependencies = [
- "alloy-json-abi",
+ "alloy-json-abi 0.8.25",
  "alloy-primitives 0.8.25",
  "alloy-sol-macro 0.8.25",
+ "const-hex",
+ "serde",
+]
+
+[[package]]
+name = "alloy-sol-types"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c02635bce18205ff8149fb752c753b0a91ea3f3c8ee04c58846448be4811a640"
+dependencies = [
+ "alloy-json-abi 1.0.0",
+ "alloy-primitives 1.0.0",
+ "alloy-sol-macro 1.0.0",
  "const-hex",
  "serde",
 ]
@@ -419,7 +529,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb00293ba84f51ce3bd026bd0de55899c4e68f0a39a5728cebae3a73ffdc0a4f"
 dependencies = [
- "ark-ec",
+ "ark-ec 0.4.2",
  "ark-ff 0.4.2",
  "ark-std 0.4.0",
 ]
@@ -431,7 +541,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20c7021f180a0cbea0380eba97c2af3c57074cdaffe0eef7e840e1c9f2841e55"
 dependencies = [
  "ark-bls12-377",
- "ark-ec",
+ "ark-ec 0.4.2",
  "ark-models-ext",
  "ark-std 0.4.0",
 ]
@@ -442,10 +552,22 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c775f0d12169cba7aae4caeb547bb6a50781c7449a8aa53793827c9ec4abf488"
 dependencies = [
- "ark-ec",
+ "ark-ec 0.4.2",
  "ark-ff 0.4.2",
  "ark-serialize 0.4.2",
  "ark-std 0.4.0",
+]
+
+[[package]]
+name = "ark-bls12-381"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3df4dcc01ff89867cd86b0da835f23c3f02738353aaee7dde7495af71363b8d5"
+dependencies = [
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
 ]
 
 [[package]]
@@ -454,8 +576,8 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1dc4b3d08f19e8ec06e949712f95b8361e43f1391d94f65e4234df03480631c"
 dependencies = [
- "ark-bls12-381",
- "ark-ec",
+ "ark-bls12-381 0.4.0",
+ "ark-ec 0.4.2",
  "ark-ff 0.4.2",
  "ark-models-ext",
  "ark-serialize 0.4.2",
@@ -469,7 +591,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e0605daf0cc5aa2034b78d008aaf159f56901d92a52ee4f6ecdfdac4f426700"
 dependencies = [
  "ark-bls12-377",
- "ark-ec",
+ "ark-ec 0.4.2",
  "ark-ff 0.4.2",
  "ark-std 0.4.0",
 ]
@@ -481,7 +603,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccee5fba47266f460067588ee1bf070a9c760bf2050c1c509982c5719aadb4f2"
 dependencies = [
  "ark-bw6-761",
- "ark-ec",
+ "ark-ec 0.4.2",
  "ark-ff 0.4.2",
  "ark-models-ext",
  "ark-std 0.4.0",
@@ -494,7 +616,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "defd9a439d56ac24968cca0571f598a61bc8c55f71d50a89cda591cb750670ba"
 dependencies = [
  "ark-ff 0.4.2",
- "ark-poly",
+ "ark-poly 0.4.2",
  "ark-serialize 0.4.2",
  "ark-std 0.4.0",
  "derivative",
@@ -506,13 +628,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
+dependencies = [
+ "ahash 0.8.11",
+ "ark-ff 0.5.0",
+ "ark-poly 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.2",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
 name = "ark-ed-on-bls12-377"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b10d901b9ac4b38f9c32beacedfadcdd64e46f8d7f8e88c1ae1060022cf6f6c6"
 dependencies = [
  "ark-bls12-377",
- "ark-ec",
+ "ark-ec 0.4.2",
  "ark-ff 0.4.2",
  "ark-std 0.4.0",
 ]
@@ -523,7 +666,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524a4fb7540df2e1a8c2e67a83ba1d1e6c3947f4f9342cc2359fc2e789ad731d"
 dependencies = [
- "ark-ec",
+ "ark-ec 0.4.2",
  "ark-ed-on-bls12-377",
  "ark-ff 0.4.2",
  "ark-models-ext",
@@ -536,10 +679,22 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9cde0f2aa063a2a5c28d39b47761aa102bda7c13c84fc118a61b87c7b2f785c"
 dependencies = [
- "ark-bls12-381",
- "ark-ec",
+ "ark-bls12-381 0.4.0",
+ "ark-ec 0.4.2",
  "ark-ff 0.4.2",
  "ark-std 0.4.0",
+]
+
+[[package]]
+name = "ark-ed-on-bls12-381-bandersnatch"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1786b2e3832f6f0f7c8d62d5d5a282f6952a1ab99981c54cd52b6ac1d8f02df5"
+dependencies = [
+ "ark-bls12-381 0.5.0",
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-std 0.5.0",
 ]
 
 [[package]]
@@ -548,8 +703,8 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d15185f1acb49a07ff8cbe5f11a1adc5a93b19e211e325d826ae98e98e124346"
 dependencies = [
- "ark-ec",
- "ark-ed-on-bls12-381-bandersnatch",
+ "ark-ec 0.4.2",
+ "ark-ed-on-bls12-381-bandersnatch 0.4.0",
  "ark-ff 0.4.2",
  "ark-models-ext",
  "ark-std 0.4.0",
@@ -594,6 +749,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a177aba0ed1e0fbb62aa9f6d0502e9b46dad8c2eab04c14258a1212d2557ea70"
+dependencies = [
+ "ark-ff-asm 0.5.0",
+ "ark-ff-macros 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "arrayvec 0.7.6",
+ "digest 0.10.7",
+ "educe",
+ "itertools 0.13.0",
+ "num-bigint",
+ "num-traits",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
 name = "ark-ff-asm"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -611,6 +786,16 @@ checksum = "3ed4aa4fe255d0bc6d79373f7e31d2ea147bcf486cba1be5ba7ea85abdb92348"
 dependencies = [
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-ff-asm"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
+dependencies = [
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -639,12 +824,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-ff-macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09be120733ee33f7693ceaa202ca41accd5653b779563608f1234f78ae07c4b3"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "ark-models-ext"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e9eab5d4b5ff2f228b763d38442adc9b084b0a465409b059fac5c2308835ec2"
 dependencies = [
- "ark-ec",
+ "ark-ec 0.4.2",
  "ark-ff 0.4.2",
  "ark-serialize 0.4.2",
  "ark-std 0.4.0",
@@ -665,32 +863,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-poly"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "579305839da207f02b89cd1679e50e67b4331e2f9294a57693e5051b7703fe27"
+dependencies = [
+ "ahash 0.8.11",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.15.2",
+]
+
+[[package]]
 name = "ark-scale"
 version = "0.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f69c00b3b529be29528a6f2fd5fa7b1790f8bed81b9cdca17e326538545a179"
 dependencies = [
- "ark-ec",
+ "ark-ec 0.4.2",
  "ark-ff 0.4.2",
  "ark-serialize 0.4.2",
  "ark-std 0.4.0",
  "parity-scale-codec",
  "scale-info",
-]
-
-[[package]]
-name = "ark-secret-scalar"
-version = "0.0.2"
-source = "git+https://github.com/davxy/ring-vrf?branch=locked#c64ae9b1aad7755ae1bf88016002365ffcc4912e"
-dependencies = [
- "ark-ec",
- "ark-ff 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "ark-transcript 0.0.2 (git+https://github.com/davxy/ring-vrf?branch=locked)",
- "digest 0.10.7",
- "getrandom_or_panic",
- "zeroize",
 ]
 
 [[package]]
@@ -709,8 +907,21 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
- "ark-serialize-derive",
+ "ark-serialize-derive 0.4.2",
  "ark-std 0.4.0",
+ "digest 0.10.7",
+ "num-bigint",
+]
+
+[[package]]
+name = "ark-serialize"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f4d068aaf107ebcd7dfb52bc748f8030e0fc930ac8e360146ca54c1203088f7"
+dependencies = [
+ "ark-serialize-derive 0.5.0",
+ "ark-std 0.5.0",
+ "arrayvec 0.7.6",
  "digest 0.10.7",
  "num-bigint",
 ]
@@ -724,6 +935,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "ark-serialize-derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -748,29 +970,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "ark-transcript"
-version = "0.0.2"
-source = "git+https://github.com/davxy/ring-vrf?branch=locked#c64ae9b1aad7755ae1bf88016002365ffcc4912e"
+name = "ark-std"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "246a225cc6131e9ee4f24619af0f19d67761fff15d7ccc22e42b80846e69449a"
 dependencies = [
- "ark-ff 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "ark-transcript"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47c1c928edb9d8ff24cb5dcb7651d3a98494fff3099eee95c2404cd813a9139f"
+dependencies = [
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
  "digest 0.10.7",
  "rand_core 0.6.4",
  "sha3",
 ]
 
 [[package]]
-name = "ark-transcript"
-version = "0.0.2"
-source = "git+https://github.com/w3f/ark-transcript?rev=288e49d#288e49ddba6f8f8e67be6822715afe36b11c4e65"
+name = "ark-vrf"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9501da18569b2afe0eb934fb7afd5a247d238b94116155af4dd068f319adfe6d"
 dependencies = [
- "ark-ff 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
+ "ark-bls12-381 0.5.0",
+ "ark-ec 0.5.0",
+ "ark-ed-on-bls12-381-bandersnatch 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
  "digest 0.10.7",
- "rand_core 0.6.4",
- "sha3",
+ "rand_chacha 0.3.1",
+ "sha2 0.10.8",
+ "w3f-ring-proof",
+ "zeroize",
 ]
 
 [[package]]
@@ -1058,27 +1297,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bandersnatch_vrfs"
-version = "0.0.4"
-source = "git+https://github.com/davxy/ring-vrf?branch=locked#c64ae9b1aad7755ae1bf88016002365ffcc4912e"
-dependencies = [
- "ark-bls12-381",
- "ark-ec",
- "ark-ed-on-bls12-381-bandersnatch",
- "ark-ff 0.4.2",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "dleq_vrf",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
- "ring 0.1.0",
- "sha2 0.10.8",
- "sp-ark-bls12-381",
- "sp-ark-ed-on-bls12-381-bandersnatch",
- "zeroize",
-]
-
-[[package]]
 name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1110,32 +1328,23 @@ checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
 name = "binary-merkle-tree"
-version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
-dependencies = [
- "hash-db",
- "log",
- "parity-scale-codec",
-]
-
-[[package]]
-name = "binary-merkle-tree"
-version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "hash-db",
- "log",
- "parity-scale-codec",
-]
-
-[[package]]
-name = "binary-merkle-tree"
 version = "15.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "336bf780dd7526a9a4bc1521720b25c1994dc132cccd59553431923fa4d1a693"
 dependencies = [
  "hash-db",
  "log",
+]
+
+[[package]]
+name = "binary-merkle-tree"
+version = "16.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "181f5380e435b8ba6d901f8b16fc8908c6f0f8bea8973113d1c8718d89bb1809"
+dependencies = [
+ "hash-db",
+ "log",
+ "parity-scale-codec",
 ]
 
 [[package]]
@@ -1421,7 +1630,7 @@ dependencies = [
  "sp-consensus-grandpa",
  "sp-core 34.0.0",
  "sp-runtime 39.0.5",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
 ]
 
 [[package]]
@@ -1438,7 +1647,7 @@ dependencies = [
  "serde",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
 ]
 
 [[package]]
@@ -1456,7 +1665,7 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-runtime 39.0.5",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
 ]
 
 [[package]]
@@ -1470,7 +1679,7 @@ dependencies = [
  "bp-runtime",
  "frame-support 38.2.0",
  "sp-api 34.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
 ]
 
 [[package]]
@@ -1489,7 +1698,7 @@ dependencies = [
  "serde",
  "sp-core 34.0.0",
  "sp-runtime 39.0.5",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
 ]
 
 [[package]]
@@ -1508,7 +1717,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime 39.0.5",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
 ]
 
 [[package]]
@@ -1530,7 +1739,7 @@ dependencies = [
  "sp-io 38.0.0",
  "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
  "sp-trie 37.0.0",
  "trie-db 0.29.1",
 ]
@@ -1552,7 +1761,7 @@ dependencies = [
  "sp-consensus-grandpa",
  "sp-core 34.0.0",
  "sp-runtime 39.0.5",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
  "sp-trie 37.0.0",
 ]
 
@@ -1570,7 +1779,7 @@ dependencies = [
  "serde",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
  "staging-xcm 14.2.1",
 ]
 
@@ -1601,7 +1810,7 @@ dependencies = [
  "snowbridge-core",
  "sp-core 34.0.0",
  "sp-runtime 39.0.5",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
  "staging-xcm 14.2.1",
 ]
 
@@ -1643,7 +1852,7 @@ dependencies = [
  "sp-io 38.0.0",
  "sp-keyring 39.0.0",
  "sp-runtime 39.0.5",
- "sp-tracing 17.0.1",
+ "sp-tracing",
  "staging-xcm 14.2.1",
  "staging-xcm-builder 17.0.4",
  "staging-xcm-executor 17.0.1",
@@ -1674,7 +1883,7 @@ dependencies = [
  "scale-info",
  "sp-io 38.0.0",
  "sp-runtime 39.0.5",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
  "sp-trie 37.0.0",
  "staging-xcm 14.2.1",
  "tuplex",
@@ -1816,8 +2025,8 @@ dependencies = [
  "semver 1.0.26",
  "serde",
  "serde_json",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-weights 27.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
+ "sp-core 36.1.0",
+ "sp-weights",
  "substrate-build-script-utils",
  "subxt",
  "tempfile",
@@ -2036,20 +2245,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "common"
-version = "0.1.0"
-source = "git+https://github.com/davxy/ring-proof?branch=locked#a24b371b8d51725ac2ce195aa3369b31df6c9873"
-dependencies = [
- "ark-ec",
- "ark-ff 0.4.2",
- "ark-poly",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "fflonk",
- "getrandom_or_panic",
-]
-
-[[package]]
 name = "common-path"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2187,7 +2382,7 @@ dependencies = [
 name = "contract-build"
 version = "6.0.0-alpha"
 dependencies = [
- "alloy-json-abi",
+ "alloy-json-abi 0.8.25",
  "anyhow",
  "blake2",
  "bollard",
@@ -2203,7 +2398,7 @@ dependencies = [
  "ink_metadata",
  "itertools 0.13.0",
  "parity-scale-codec",
- "polkavm-linker 0.21.0 (git+https://github.com/paritytech/polkavm)",
+ "polkavm-linker 0.22.0",
  "pretty_assertions",
  "regex",
  "rustc_version 0.4.1",
@@ -2243,8 +2438,8 @@ dependencies = [
  "ink_env",
  "ink_metadata",
  "itertools 0.14.0",
- "pallet-revive 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "pallet-revive-uapi 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
+ "pallet-revive 0.5.0",
+ "pallet-revive-uapi 0.4.0",
  "parity-scale-codec",
  "predicates",
  "regex",
@@ -2252,9 +2447,9 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-weights 27.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
+ "sp-core 36.1.0",
+ "sp-runtime 41.1.0",
+ "sp-weights",
  "stdio-override",
  "subxt",
  "subxt-signer",
@@ -2302,8 +2497,8 @@ dependencies = [
  "scale-info",
  "serde",
  "serde_json",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-keyring 31.0.0",
+ "sp-core 36.1.0",
+ "sp-keyring 41.0.0",
  "strsim",
  "thiserror 2.0.12",
  "tracing",
@@ -2643,7 +2838,7 @@ dependencies = [
  "sp-io 38.0.0",
  "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
  "sp-trie 37.0.0",
  "sp-version 37.0.0",
  "staging-xcm 14.2.1",
@@ -3201,22 +3396,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dleq_vrf"
-version = "0.0.2"
-source = "git+https://github.com/davxy/ring-vrf?branch=locked#c64ae9b1aad7755ae1bf88016002365ffcc4912e"
-dependencies = [
- "ark-ec",
- "ark-ff 0.4.2",
- "ark-scale",
- "ark-secret-scalar",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "ark-transcript 0.0.2 (git+https://github.com/davxy/ring-vrf?branch=locked)",
- "arrayvec 0.7.6",
- "zeroize",
-]
-
-[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3355,6 +3534,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "educe"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d7bc049e1bd8cdeb31b68bbd586a9464ecf9f3944af3958a7a9d0f8b9799417"
+dependencies = [
+ "enum-ordinalize",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3394,6 +3585,26 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "enum-ordinalize"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fea0dcfa4e54eeb516fe454635a95753ddd39acda650ce703031c6973e315dd5"
+dependencies = [
+ "enum-ordinalize-derive",
+]
+
+[[package]]
+name = "enum-ordinalize-derive"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
 
 [[package]]
 name = "enumflags2"
@@ -3653,19 +3864,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fflonk"
-version = "0.1.0"
-source = "git+https://github.com/w3f/fflonk?rev=1e854f3#1e854f35e9a65d08b11a86291405cdc95baa0a35"
-dependencies = [
- "ark-ec",
- "ark-ff 0.4.2",
- "ark-poly",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "merlin",
-]
-
-[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3784,54 +3982,6 @@ dependencies = [
 
 [[package]]
 name = "frame-benchmarking"
-version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
-dependencies = [
- "frame-support 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "frame-support-procedural 23.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "frame-system 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "linregress",
- "log",
- "parity-scale-codec",
- "paste",
- "scale-info",
- "serde",
- "sp-api 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-application-crypto 30.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "static_assertions",
-]
-
-[[package]]
-name = "frame-benchmarking"
-version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "frame-support 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "frame-support-procedural 23.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "frame-system 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "linregress",
- "log",
- "parity-scale-codec",
- "paste",
- "scale-info",
- "serde",
- "sp-api 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-application-crypto 30.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "static_assertions",
-]
-
-[[package]]
-name = "frame-benchmarking"
 version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a01bdd47c2d541b38bd892da647d1e972c9d85b4ecd7094ad64f7600175da54d"
@@ -3852,6 +4002,31 @@ dependencies = [
  "sp-runtime 39.0.5",
  "sp-runtime-interface 28.0.0",
  "sp-storage 21.0.0",
+ "static_assertions",
+]
+
+[[package]]
+name = "frame-benchmarking"
+version = "40.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55b0892434d3cc61fab58b2e48b27b12fc162465c5af48fa283ed15bb86dbfb2"
+dependencies = [
+ "frame-support 40.1.0",
+ "frame-support-procedural 33.0.0",
+ "frame-system 40.1.0",
+ "linregress",
+ "log",
+ "parity-scale-codec",
+ "paste",
+ "scale-info",
+ "serde",
+ "sp-api 36.0.1",
+ "sp-application-crypto 40.1.0",
+ "sp-core 36.1.0",
+ "sp-io 40.0.0",
+ "sp-runtime 41.1.0",
+ "sp-runtime-interface 29.0.1",
+ "sp-storage 22.0.0",
  "static_assertions",
 ]
 
@@ -3881,7 +4056,7 @@ dependencies = [
  "scale-decode",
  "scale-info",
  "scale-type-resolver",
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-crypto-hashing",
 ]
 
 [[package]]
@@ -3907,7 +4082,7 @@ dependencies = [
  "frame-system 38.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic 26.0.0",
+ "sp-arithmetic",
  "sp-core 34.0.0",
  "sp-npos-elections",
  "sp-runtime 39.0.5",
@@ -3929,7 +4104,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-runtime 39.0.5",
- "sp-tracing 17.0.1",
+ "sp-tracing",
 ]
 
 [[package]]
@@ -3986,92 +4161,6 @@ dependencies = [
 
 [[package]]
 name = "frame-support"
-version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
-dependencies = [
- "aquamarine",
- "array-bytes",
- "binary-merkle-tree 13.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "bitflags 1.3.2",
- "docify",
- "environmental",
- "frame-metadata 20.0.0",
- "frame-support-procedural 23.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "impl-trait-for-tuples",
- "k256",
- "log",
- "macro_magic",
- "parity-scale-codec",
- "paste",
- "scale-info",
- "serde",
- "serde_json",
- "smallvec",
- "sp-api 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-arithmetic 23.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-crypto-hashing-proc-macro 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-genesis-builder 0.8.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-inherents 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-metadata-ir 0.6.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-staking 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-state-machine 0.35.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-trie 29.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-weights 27.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "static_assertions",
- "tt-call",
-]
-
-[[package]]
-name = "frame-support"
-version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "aquamarine",
- "array-bytes",
- "binary-merkle-tree 13.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "bitflags 1.3.2",
- "docify",
- "environmental",
- "frame-metadata 20.0.0",
- "frame-support-procedural 23.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "impl-trait-for-tuples",
- "k256",
- "log",
- "macro_magic",
- "parity-scale-codec",
- "paste",
- "scale-info",
- "serde",
- "serde_json",
- "smallvec",
- "sp-api 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-arithmetic 23.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-crypto-hashing-proc-macro 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-genesis-builder 0.8.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-inherents 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-metadata-ir 0.6.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-staking 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-state-machine 0.35.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-trie 29.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-weights 27.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "static_assertions",
- "tt-call",
-]
-
-[[package]]
-name = "frame-support"
 version = "38.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7dd8b9f161a8289e3b9fe6c1068519358dbff2270d38097a923d3d1b4459dca"
@@ -4094,10 +4183,10 @@ dependencies = [
  "serde_json",
  "smallvec",
  "sp-api 34.0.0",
- "sp-arithmetic 26.0.0",
+ "sp-arithmetic",
  "sp-core 34.0.0",
- "sp-crypto-hashing-proc-macro 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-debug-derive 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-crypto-hashing-proc-macro",
+ "sp-debug-derive",
  "sp-genesis-builder 0.15.1",
  "sp-inherents 34.0.0",
  "sp-io 38.0.0",
@@ -4105,51 +4194,53 @@ dependencies = [
  "sp-runtime 39.0.5",
  "sp-staking 36.0.0",
  "sp-state-machine 0.43.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-tracing 17.0.1",
- "sp-weights 31.0.0",
+ "sp-std",
+ "sp-tracing",
+ "sp-weights",
  "static_assertions",
  "tt-call",
 ]
 
 [[package]]
-name = "frame-support-procedural"
-version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
+name = "frame-support"
+version = "40.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d6c7c272704856cc88a86aef689a778050e59f89d7ec1e4ffb3a9e8e04e6b10"
 dependencies = [
- "Inflector",
- "cfg-expr",
- "derive-syn-parse",
+ "aquamarine",
+ "array-bytes",
+ "binary-merkle-tree 16.0.0",
+ "bitflags 1.3.2",
  "docify",
- "expander",
- "frame-support-procedural-tools 10.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "itertools 0.11.0",
+ "environmental",
+ "frame-metadata 20.0.0",
+ "frame-support-procedural 33.0.0",
+ "impl-trait-for-tuples",
+ "k256",
+ "log",
  "macro_magic",
- "proc-macro-warning",
- "proc-macro2",
- "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "frame-support-procedural"
-version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "Inflector",
- "cfg-expr",
- "derive-syn-parse",
- "docify",
- "expander",
- "frame-support-procedural-tools 10.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "itertools 0.11.0",
- "macro_magic",
- "proc-macro-warning",
- "proc-macro2",
- "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "syn 2.0.100",
+ "parity-scale-codec",
+ "paste",
+ "scale-info",
+ "serde",
+ "serde_json",
+ "sp-api 36.0.1",
+ "sp-arithmetic",
+ "sp-core 36.1.0",
+ "sp-crypto-hashing-proc-macro",
+ "sp-debug-derive",
+ "sp-genesis-builder 0.17.0",
+ "sp-inherents 36.0.0",
+ "sp-io 40.0.0",
+ "sp-metadata-ir 0.10.0",
+ "sp-runtime 41.1.0",
+ "sp-staking 38.0.0",
+ "sp-state-machine 0.45.0",
+ "sp-std",
+ "sp-tracing",
+ "sp-trie 39.1.0",
+ "sp-weights",
+ "tt-call",
 ]
 
 [[package]]
@@ -4163,37 +4254,34 @@ dependencies = [
  "derive-syn-parse",
  "docify",
  "expander",
- "frame-support-procedural-tools 13.0.1",
+ "frame-support-procedural-tools",
  "itertools 0.11.0",
  "macro_magic",
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-crypto-hashing",
  "syn 2.0.100",
 ]
 
 [[package]]
-name = "frame-support-procedural-tools"
-version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
+name = "frame-support-procedural"
+version = "33.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73bc18090aa96a5e69cd566fb755b5be08964b926864b2101dd900f64a870437"
 dependencies = [
- "frame-support-procedural-tools-derive 11.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "proc-macro-crate",
+ "Inflector",
+ "cfg-expr",
+ "derive-syn-parse",
+ "docify",
+ "expander",
+ "frame-support-procedural-tools",
+ "itertools 0.11.0",
+ "macro_magic",
+ "proc-macro-warning",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "frame-support-procedural-tools"
-version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "frame-support-procedural-tools-derive 11.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
+ "sp-crypto-hashing",
  "syn 2.0.100",
 ]
 
@@ -4203,28 +4291,8 @@ version = "13.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81a088fd6fda5f53ff0c17fc7551ce8bd0ead14ba742228443c8196296a7369b"
 dependencies = [
- "frame-support-procedural-tools-derive 12.0.0",
+ "frame-support-procedural-tools-derive",
  "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "frame-support-procedural-tools-derive"
-version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "frame-support-procedural-tools-derive"
-version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -4243,44 +4311,6 @@ dependencies = [
 
 [[package]]
 name = "frame-system"
-version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
-dependencies = [
- "cfg-if",
- "docify",
- "frame-support 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "log",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-version 29.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-weights 27.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
-]
-
-[[package]]
-name = "frame-system"
-version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "cfg-if",
- "docify",
- "frame-support 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "log",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-version 29.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-weights 27.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
-]
-
-[[package]]
-name = "frame-system"
 version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c7fa02f8c305496d2ae52edaecdb9d165f11afa965e05686d7d7dd1ce93611"
@@ -4295,9 +4325,29 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-runtime 39.0.5",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
  "sp-version 37.0.0",
- "sp-weights 31.0.0",
+ "sp-weights",
+]
+
+[[package]]
+name = "frame-system"
+version = "40.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfc20d95c35bad22eb8b8d7ef91197a439483458237b176e621d9210f2fbff15"
+dependencies = [
+ "cfg-if",
+ "docify",
+ "frame-support 40.1.0",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core 36.1.0",
+ "sp-io 40.0.0",
+ "sp-runtime 41.1.0",
+ "sp-version 39.0.0",
+ "sp-weights",
 ]
 
 [[package]]
@@ -5150,9 +5200,8 @@ checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
 [[package]]
 name = "ink"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#38594e3adfa6a4918d07b31f063526454540e4f3"
+source = "git+https://github.com/use-ink/ink?branch=alex/update-dependencies#726bd25b4499aba8c97cd623855bbe38d4940e72"
 dependencies = [
- "alloy-sol-types 0.8.25",
  "const_format",
  "deranged",
  "derive_more 2.0.1",
@@ -5163,19 +5212,19 @@ dependencies = [
  "ink_primitives",
  "ink_storage",
  "keccak-const",
- "pallet-revive-uapi 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
+ "pallet-revive-uapi 0.4.0",
  "parity-scale-codec",
- "polkavm-derive 0.21.0 (git+https://github.com/paritytech/polkavm)",
+ "polkavm-derive 0.22.0",
  "scale-info",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "staging-xcm 7.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
+ "sp-io 40.0.0",
+ "sp-runtime-interface 29.0.1",
+ "staging-xcm 16.1.0",
 ]
 
 [[package]]
 name = "ink_allocator"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#38594e3adfa6a4918d07b31f063526454540e4f3"
+source = "git+https://github.com/use-ink/ink?branch=alex/update-dependencies#726bd25b4499aba8c97cd623855bbe38d4940e72"
 dependencies = [
  "cfg-if",
 ]
@@ -5183,7 +5232,7 @@ dependencies = [
 [[package]]
 name = "ink_codegen"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#38594e3adfa6a4918d07b31f063526454540e4f3"
+source = "git+https://github.com/use-ink/ink?branch=alex/update-dependencies#726bd25b4499aba8c97cd623855bbe38d4940e72"
 dependencies = [
  "blake2",
  "derive_more 2.0.1",
@@ -5194,7 +5243,7 @@ dependencies = [
  "ink_primitives",
  "itertools 0.14.0",
  "parity-scale-codec",
- "polkavm-derive 0.21.0 (git+https://github.com/paritytech/polkavm)",
+ "polkavm-derive 0.22.0",
  "proc-macro2",
  "quote",
  "serde",
@@ -5205,14 +5254,14 @@ dependencies = [
 [[package]]
 name = "ink_engine"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#38594e3adfa6a4918d07b31f063526454540e4f3"
+source = "git+https://github.com/use-ink/ink?branch=alex/update-dependencies#726bd25b4499aba8c97cd623855bbe38d4940e72"
 dependencies = [
  "blake2",
  "derive_more 2.0.1",
  "hex-literal 1.0.0",
  "ink_primitives",
- "pallet-revive 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "pallet-revive-uapi 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
+ "pallet-revive 0.5.0",
+ "pallet-revive-uapi 0.4.0",
  "parity-scale-codec",
  "secp256k1 0.30.0",
  "sha2 0.10.8",
@@ -5222,9 +5271,8 @@ dependencies = [
 [[package]]
 name = "ink_env"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#38594e3adfa6a4918d07b31f063526454540e4f3"
+source = "git+https://github.com/use-ink/ink?branch=alex/update-dependencies#726bd25b4499aba8c97cd623855bbe38d4940e72"
 dependencies = [
- "alloy-sol-types 0.8.25",
  "blake2",
  "cfg-if",
  "const_env",
@@ -5237,10 +5285,10 @@ dependencies = [
  "ink_primitives",
  "ink_storage_traits",
  "num-traits",
- "pallet-revive 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "pallet-revive-uapi 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
+ "pallet-revive 0.5.0",
+ "pallet-revive-uapi 0.4.0",
  "parity-scale-codec",
- "polkavm-derive 0.21.0 (git+https://github.com/paritytech/polkavm)",
+ "polkavm-derive 0.22.0",
  "scale-decode",
  "scale-encode",
  "scale-info",
@@ -5248,16 +5296,16 @@ dependencies = [
  "secp256k1 0.30.0",
  "sha2 0.10.8",
  "sha3",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "staging-xcm 7.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
+ "sp-io 40.0.0",
+ "sp-runtime-interface 29.0.1",
+ "staging-xcm 16.1.0",
  "static_assertions",
 ]
 
 [[package]]
 name = "ink_ir"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#38594e3adfa6a4918d07b31f063526454540e4f3"
+source = "git+https://github.com/use-ink/ink?branch=alex/update-dependencies#726bd25b4499aba8c97cd623855bbe38d4940e72"
 dependencies = [
  "blake2",
  "either",
@@ -5273,7 +5321,7 @@ dependencies = [
 [[package]]
 name = "ink_macro"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#38594e3adfa6a4918d07b31f063526454540e4f3"
+source = "git+https://github.com/use-ink/ink?branch=alex/update-dependencies#726bd25b4499aba8c97cd623855bbe38d4940e72"
 dependencies = [
  "ink_codegen",
  "ink_ir",
@@ -5288,7 +5336,7 @@ dependencies = [
 [[package]]
 name = "ink_metadata"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#38594e3adfa6a4918d07b31f063526454540e4f3"
+source = "git+https://github.com/use-ink/ink?branch=alex/update-dependencies#726bd25b4499aba8c97cd623855bbe38d4940e72"
 dependencies = [
  "derive_more 2.0.1",
  "impl-serde 0.5.0",
@@ -5304,7 +5352,7 @@ dependencies = [
 [[package]]
 name = "ink_prelude"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#38594e3adfa6a4918d07b31f063526454540e4f3"
+source = "git+https://github.com/use-ink/ink?branch=alex/update-dependencies#726bd25b4499aba8c97cd623855bbe38d4940e72"
 dependencies = [
  "cfg-if",
 ]
@@ -5312,31 +5360,34 @@ dependencies = [
 [[package]]
 name = "ink_primitives"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#38594e3adfa6a4918d07b31f063526454540e4f3"
+source = "git+https://github.com/use-ink/ink?branch=alex/update-dependencies#726bd25b4499aba8c97cd623855bbe38d4940e72"
 dependencies = [
- "alloy-sol-types 0.8.25",
+ "alloy-sol-types 1.0.0",
  "cfg-if",
  "derive_more 2.0.1",
+ "impl-trait-for-tuples",
  "ink_prelude",
+ "itertools 0.14.0",
  "num-traits",
- "pallet-revive 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "pallet-revive-uapi 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
+ "pallet-revive 0.5.0",
+ "pallet-revive-uapi 0.4.0",
  "parity-scale-codec",
+ "paste",
  "primitive-types 0.13.1",
  "scale-decode",
  "scale-encode",
  "scale-info",
  "serde",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
+ "sp-core 36.1.0",
+ "sp-io 40.0.0",
+ "sp-runtime-interface 29.0.1",
  "xxhash-rust",
 ]
 
 [[package]]
 name = "ink_storage"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#38594e3adfa6a4918d07b31f063526454540e4f3"
+source = "git+https://github.com/use-ink/ink?branch=alex/update-dependencies#726bd25b4499aba8c97cd623855bbe38d4940e72"
 dependencies = [
  "array-init",
  "cfg-if",
@@ -5346,7 +5397,7 @@ dependencies = [
  "ink_prelude",
  "ink_primitives",
  "ink_storage_traits",
- "pallet-revive-uapi 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
+ "pallet-revive-uapi 0.4.0",
  "parity-scale-codec",
  "scale-info",
 ]
@@ -5354,15 +5405,15 @@ dependencies = [
 [[package]]
 name = "ink_storage_traits"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#38594e3adfa6a4918d07b31f063526454540e4f3"
+source = "git+https://github.com/use-ink/ink?branch=alex/update-dependencies#726bd25b4499aba8c97cd623855bbe38d4940e72"
 dependencies = [
  "ink_metadata",
  "ink_prelude",
  "ink_primitives",
  "parity-scale-codec",
  "scale-info",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
+ "sp-io 40.0.0",
+ "sp-runtime-interface 29.0.1",
 ]
 
 [[package]]
@@ -6296,45 +6347,9 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-crypto-hashing",
  "sp-io 38.0.0",
  "sp-runtime 39.0.5",
-]
-
-[[package]]
-name = "pallet-asset-conversion"
-version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
-dependencies = [
- "frame-benchmarking 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "frame-support 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "frame-system 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-api 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-arithmetic 23.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
-]
-
-[[package]]
-name = "pallet-asset-conversion"
-version = "10.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "frame-benchmarking 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "frame-support 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "frame-system 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-api 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-arithmetic 23.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
 ]
 
 [[package]]
@@ -6350,10 +6365,29 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api 34.0.0",
- "sp-arithmetic 26.0.0",
+ "sp-arithmetic",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-runtime 39.0.5",
+]
+
+[[package]]
+name = "pallet-asset-conversion"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e063e39ad8ecd3c2b00c963f50cdf79e614c819a01e1c1ce9993287075b1b4d9"
+dependencies = [
+ "frame-benchmarking 40.0.0",
+ "frame-support 40.1.0",
+ "frame-system 40.1.0",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api 36.0.1",
+ "sp-arithmetic",
+ "sp-core 36.1.0",
+ "sp-io 40.0.0",
+ "sp-runtime 41.1.0",
 ]
 
 [[package]]
@@ -6369,7 +6403,7 @@ dependencies = [
  "pallet-asset-conversion 20.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic 26.0.0",
+ "sp-arithmetic",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-runtime 39.0.5",
@@ -6561,7 +6595,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-runtime 39.0.5",
- "sp-tracing 17.0.1",
+ "sp-tracing",
 ]
 
 [[package]]
@@ -6661,7 +6695,7 @@ dependencies = [
  "scale-info",
  "sp-consensus-grandpa",
  "sp-runtime 39.0.5",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
 ]
 
 [[package]]
@@ -6680,7 +6714,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime 39.0.5",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
  "sp-trie 37.0.0",
 ]
 
@@ -6702,7 +6736,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime 39.0.5",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
 ]
 
 [[package]]
@@ -6725,9 +6759,9 @@ dependencies = [
  "pallet-transaction-payment 38.0.2",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic 26.0.0",
+ "sp-arithmetic",
  "sp-runtime 39.0.5",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
 ]
 
 [[package]]
@@ -6744,7 +6778,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api 34.0.0",
- "sp-arithmetic 26.0.0",
+ "sp-arithmetic",
  "sp-core 34.0.0",
  "sp-runtime 39.0.5",
 ]
@@ -6846,7 +6880,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-runtime 39.0.5",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
  "staging-xcm 14.2.1",
  "staging-xcm-builder 17.0.4",
  "wasm-instrument",
@@ -6882,7 +6916,7 @@ dependencies = [
  "sp-io 38.0.0",
  "sp-keystore 0.40.0",
  "sp-runtime 39.0.5",
- "sp-tracing 17.0.1",
+ "sp-tracing",
  "staging-xcm 14.2.1",
  "staging-xcm-builder 17.0.4",
  "staging-xcm-executor 17.0.1",
@@ -6942,7 +6976,7 @@ dependencies = [
  "pallet-ranked-collective",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic 26.0.0",
+ "sp-arithmetic",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-runtime 39.0.5",
@@ -7013,7 +7047,7 @@ dependencies = [
  "parity-scale-codec",
  "rand 0.8.5",
  "scale-info",
- "sp-arithmetic 26.0.0",
+ "sp-arithmetic",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-npos-elections",
@@ -7227,11 +7261,11 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic 26.0.0",
+ "sp-arithmetic",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-runtime 39.0.5",
- "sp-weights 31.0.0",
+ "sp-weights",
 ]
 
 [[package]]
@@ -7266,7 +7300,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-application-crypto 38.0.0",
- "sp-arithmetic 26.0.0",
+ "sp-arithmetic",
  "sp-io 38.0.0",
  "sp-mixnet",
  "sp-runtime 39.0.5",
@@ -7363,7 +7397,7 @@ dependencies = [
  "frame-system 38.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic 26.0.0",
+ "sp-arithmetic",
  "sp-core 34.0.0",
  "sp-runtime 39.0.5",
 ]
@@ -7400,7 +7434,7 @@ dependencies = [
  "sp-io 38.0.0",
  "sp-runtime 39.0.5",
  "sp-staking 36.0.0",
- "sp-tracing 17.0.1",
+ "sp-tracing",
 ]
 
 [[package]]
@@ -7557,7 +7591,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic 26.0.0",
+ "sp-arithmetic",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-runtime 39.0.5",
@@ -7591,7 +7625,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-arithmetic 26.0.0",
+ "sp-arithmetic",
  "sp-io 38.0.0",
  "sp-runtime 39.0.5",
 ]
@@ -7611,93 +7645,6 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-runtime 39.0.5",
-]
-
-[[package]]
-name = "pallet-revive"
-version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
-dependencies = [
- "alloy-core",
- "derive_more 0.99.19",
- "environmental",
- "ethabi-decode 2.0.0",
- "ethereum-types 0.15.1",
- "frame-benchmarking 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "frame-support 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "frame-system 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "hex-literal 0.4.1",
- "impl-trait-for-tuples",
- "log",
- "num-bigint",
- "num-integer",
- "num-traits",
- "pallet-revive-fixtures 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "pallet-revive-proc-macro 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "pallet-revive-uapi 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "pallet-transaction-payment 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "parity-scale-codec",
- "paste",
- "polkavm 0.21.0",
- "polkavm-common 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.8.5",
- "ripemd",
- "rlp 0.6.1",
- "scale-info",
- "serde",
- "sp-api 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-arithmetic 23.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-consensus-aura 0.32.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-consensus-babe 0.32.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-consensus-slots 0.32.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "staging-xcm 7.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "staging-xcm-builder 7.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "substrate-bn",
- "subxt-signer",
-]
-
-[[package]]
-name = "pallet-revive"
-version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "alloy-core",
- "derive_more 0.99.19",
- "environmental",
- "ethabi-decode 2.0.0",
- "ethereum-types 0.15.1",
- "frame-benchmarking 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "frame-support 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "frame-system 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "hex-literal 0.4.1",
- "impl-trait-for-tuples",
- "log",
- "pallet-revive-fixtures 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "pallet-revive-proc-macro 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "pallet-revive-uapi 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "pallet-transaction-payment 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "parity-scale-codec",
- "paste",
- "polkavm 0.21.0",
- "polkavm-common 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.8.5",
- "rlp 0.6.1",
- "scale-info",
- "serde",
- "sp-api 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-arithmetic 23.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-consensus-aura 0.32.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-consensus-babe 0.32.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-consensus-slots 0.32.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "staging-xcm 7.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "staging-xcm-builder 7.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "subxt-signer",
 ]
 
 [[package]]
@@ -7726,35 +7673,56 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-runtime 39.0.5",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
  "staging-xcm 14.2.1",
  "staging-xcm-builder 17.0.4",
 ]
 
 [[package]]
-name = "pallet-revive-fixtures"
-version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
+name = "pallet-revive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "895fe6f50f621a69132697b8b43d29d1db4d9ff445eec410bf1fc98cd7e9412c"
 dependencies = [
- "anyhow",
- "cargo_metadata 0.15.4",
- "pallet-revive-uapi 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "polkavm-linker 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "toml 0.8.20",
-]
-
-[[package]]
-name = "pallet-revive-fixtures"
-version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "anyhow",
- "polkavm-linker 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "toml 0.8.20",
+ "alloy-core",
+ "derive_more 0.99.19",
+ "environmental",
+ "ethabi-decode 2.0.0",
+ "ethereum-types 0.15.1",
+ "frame-benchmarking 40.0.0",
+ "frame-support 40.1.0",
+ "frame-system 40.1.0",
+ "hex-literal 0.4.1",
+ "impl-trait-for-tuples",
+ "log",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "pallet-revive-fixtures 0.3.0",
+ "pallet-revive-proc-macro 0.3.0",
+ "pallet-revive-uapi 0.4.0",
+ "pallet-transaction-payment 40.0.0",
+ "parity-scale-codec",
+ "paste",
+ "polkavm 0.21.0",
+ "polkavm-common 0.21.0",
+ "rand 0.8.5",
+ "ripemd",
+ "rlp 0.6.1",
+ "scale-info",
+ "serde",
+ "sp-api 36.0.1",
+ "sp-arithmetic",
+ "sp-consensus-aura 0.42.0",
+ "sp-consensus-babe 0.42.1",
+ "sp-consensus-slots 0.42.1",
+ "sp-core 36.1.0",
+ "sp-io 40.0.0",
+ "sp-runtime 41.1.0",
+ "staging-xcm 16.1.0",
+ "staging-xcm-builder 20.0.0",
+ "substrate-bn",
+ "subxt-signer",
 ]
 
 [[package]]
@@ -7769,6 +7737,21 @@ dependencies = [
  "polkavm-linker 0.10.0",
  "sp-runtime 39.0.5",
  "tempfile",
+ "toml 0.8.20",
+]
+
+[[package]]
+name = "pallet-revive-fixtures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1df19ca809f036d6ddf1632039e9db312f92dbe8f9390e6722ad808cd95377"
+dependencies = [
+ "anyhow",
+ "cargo_metadata 0.15.4",
+ "pallet-revive-uapi 0.4.0",
+ "polkavm-linker 0.21.0",
+ "sp-core 36.1.0",
+ "sp-io 40.0.0",
  "toml 0.8.20",
 ]
 
@@ -7800,31 +7783,11 @@ dependencies = [
  "sp-io 38.0.0",
  "sp-keystore 0.40.0",
  "sp-runtime 39.0.5",
- "sp-tracing 17.0.1",
+ "sp-tracing",
  "staging-xcm 14.2.1",
  "staging-xcm-builder 17.0.4",
  "staging-xcm-executor 17.0.1",
  "xcm-simulator",
-]
-
-[[package]]
-name = "pallet-revive-proc-macro"
-version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "pallet-revive-proc-macro"
-version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
 ]
 
 [[package]]
@@ -7839,29 +7802,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-revive-uapi"
-version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
+name = "pallet-revive-proc-macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63c2dc2fc6961da23fefc54689ce81a8e006f6988bc465dcc9ab9db905d31766"
 dependencies = [
- "bitflags 1.3.2",
- "pallet-revive-proc-macro 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "parity-scale-codec",
- "paste",
- "polkavm-derive 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "scale-info",
-]
-
-[[package]]
-name = "pallet-revive-uapi"
-version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "bitflags 1.3.2",
- "pallet-revive-proc-macro 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "parity-scale-codec",
- "paste",
- "polkavm-derive 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "scale-info",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -7874,6 +7822,19 @@ dependencies = [
  "parity-scale-codec",
  "paste",
  "polkavm-derive 0.10.0",
+ "scale-info",
+]
+
+[[package]]
+name = "pallet-revive-uapi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cb8f45102c6279f59f55e0051fc6c26b996619d7842800dfaf3a2583459a1c7"
+dependencies = [
+ "bitflags 1.3.2",
+ "pallet-revive-proc-macro 0.3.0",
+ "parity-scale-codec",
+ "polkavm-derive 0.21.0",
  "scale-info",
 ]
 
@@ -7923,7 +7884,7 @@ dependencies = [
  "pallet-utility",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic 26.0.0",
+ "sp-arithmetic",
  "sp-runtime 39.0.5",
 ]
 
@@ -7940,7 +7901,7 @@ dependencies = [
  "pallet-ranked-collective",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic 26.0.0",
+ "sp-arithmetic",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-runtime 39.0.5",
@@ -7961,7 +7922,7 @@ dependencies = [
  "scale-info",
  "sp-io 38.0.0",
  "sp-runtime 39.0.5",
- "sp-weights 31.0.0",
+ "sp-weights",
 ]
 
 [[package]]
@@ -8043,7 +8004,7 @@ dependencies = [
  "parity-scale-codec",
  "rand_chacha 0.3.1",
  "scale-info",
- "sp-arithmetic 26.0.0",
+ "sp-arithmetic",
  "sp-io 38.0.0",
  "sp-runtime 39.0.5",
 ]
@@ -8077,7 +8038,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "988a7ebeacc84d4bdb0b12409681e956ffe35438447d8f8bc78db547cffb6ebc"
 dependencies = [
  "log",
- "sp-arithmetic 26.0.0",
+ "sp-arithmetic",
 ]
 
 [[package]]
@@ -8183,38 +8144,6 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment"
-version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
-dependencies = [
- "frame-benchmarking 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "frame-support 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "frame-system 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
-]
-
-[[package]]
-name = "pallet-transaction-payment"
-version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "frame-benchmarking 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "frame-support 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "frame-system 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
-]
-
-[[package]]
-name = "pallet-transaction-payment"
 version = "38.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6cdb86580c72b58145f9cddba21a0c1814742ca56abc9caac3c1ac72f6bde649"
@@ -8230,6 +8159,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-transaction-payment"
+version = "40.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8ebd61b64848e39e5615832c964dc10b63bcebff26a9ec1cb867b4087240a03"
+dependencies = [
+ "frame-benchmarking 40.0.0",
+ "frame-support 40.1.0",
+ "frame-system 40.1.0",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core 36.1.0",
+ "sp-io 40.0.0",
+ "sp-runtime 41.1.0",
+]
+
+[[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
 version = "38.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8239,7 +8185,7 @@ dependencies = [
  "parity-scale-codec",
  "sp-api 34.0.0",
  "sp-runtime 39.0.5",
- "sp-weights 31.0.0",
+ "sp-weights",
 ]
 
 [[package]]
@@ -8421,7 +8367,7 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-runtime 39.0.5",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
  "staging-xcm 14.2.1",
  "staging-xcm-builder 17.0.4",
  "staging-xcm-executor 17.0.1",
@@ -8442,7 +8388,7 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-runtime 39.0.5",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
  "staging-xcm 14.2.1",
  "staging-xcm-builder 17.0.4",
 ]
@@ -8502,7 +8448,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-runtime 39.0.5",
- "sp-tracing 17.0.1",
+ "sp-tracing",
  "staging-parachain-info",
  "staging-xcm 14.2.1",
  "staging-xcm-executor 17.0.1",
@@ -8737,28 +8683,6 @@ dependencies = [
 
 [[package]]
 name = "polkadot-core-primitives"
-version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
-]
-
-[[package]]
-name = "polkadot-core-primitives"
-version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
-]
-
-[[package]]
-name = "polkadot-core-primitives"
 version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2900d3b857e34c480101618a950c3a4fbcddc8c0d50573d48553376185908b8"
@@ -8770,35 +8694,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "polkadot-parachain-primitives"
-version = "6.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
+name = "polkadot-core-primitives"
+version = "17.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7c519ee804fd08d7464871bd2fe164e8f0683501ea59d2a10f5ef214dacb3b"
 dependencies = [
- "bounded-collections",
- "derive_more 0.99.19",
  "parity-scale-codec",
- "polkadot-core-primitives 7.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
  "scale-info",
- "serde",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-weights 27.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
-]
-
-[[package]]
-name = "polkadot-parachain-primitives"
-version = "6.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "bounded-collections",
- "derive_more 0.99.19",
- "parity-scale-codec",
- "polkadot-core-primitives 7.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "scale-info",
- "serde",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-weights 27.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
+ "sp-core 36.1.0",
+ "sp-runtime 41.1.0",
 ]
 
 [[package]]
@@ -8815,7 +8719,24 @@ dependencies = [
  "serde",
  "sp-core 34.0.0",
  "sp-runtime 39.0.5",
- "sp-weights 31.0.0",
+ "sp-weights",
+]
+
+[[package]]
+name = "polkadot-parachain-primitives"
+version = "16.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72943c0948c686b47bacb1a03e59baff63bfba2e16e208d77f0f8615827f8564"
+dependencies = [
+ "bounded-collections",
+ "derive_more 0.99.19",
+ "parity-scale-codec",
+ "polkadot-core-primitives 17.1.0",
+ "scale-info",
+ "serde",
+ "sp-core 36.1.0",
+ "sp-runtime 41.1.0",
+ "sp-weights",
 ]
 
 [[package]]
@@ -8834,7 +8755,7 @@ dependencies = [
  "serde",
  "sp-api 34.0.0",
  "sp-application-crypto 38.0.0",
- "sp-arithmetic 26.0.0",
+ "sp-arithmetic",
  "sp-authority-discovery",
  "sp-consensus-slots 0.40.1",
  "sp-core 34.0.0",
@@ -8861,7 +8782,7 @@ dependencies = [
  "serde",
  "sp-api 34.0.0",
  "sp-application-crypto 38.0.0",
- "sp-arithmetic 26.0.0",
+ "sp-arithmetic",
  "sp-authority-discovery",
  "sp-consensus-slots 0.40.1",
  "sp-core 34.0.0",
@@ -8932,7 +8853,7 @@ dependencies = [
  "frame-benchmarking 38.0.0",
  "parity-scale-codec",
  "polkadot-primitives 16.0.0",
- "sp-tracing 17.0.1",
+ "sp-tracing",
 ]
 
 [[package]]
@@ -8971,7 +8892,7 @@ dependencies = [
  "serde",
  "sp-api 34.0.0",
  "sp-application-crypto 38.0.0",
- "sp-arithmetic 26.0.0",
+ "sp-arithmetic",
  "sp-core 34.0.0",
  "sp-inherents 34.0.0",
  "sp-io 38.0.0",
@@ -8979,7 +8900,7 @@ dependencies = [
  "sp-runtime 39.0.5",
  "sp-session",
  "sp-staking 36.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
  "staging-xcm 14.2.1",
  "staging-xcm-executor 17.0.1",
 ]
@@ -9166,7 +9087,7 @@ dependencies = [
  "sp-api 34.0.0",
  "sp-api-proc-macro 20.0.0",
  "sp-application-crypto 38.0.0",
- "sp-arithmetic 26.0.0",
+ "sp-arithmetic",
  "sp-authority-discovery",
  "sp-block-builder",
  "sp-consensus-aura 0.40.0",
@@ -9177,9 +9098,9 @@ dependencies = [
  "sp-consensus-slots 0.40.1",
  "sp-core 34.0.0",
  "sp-core-hashing",
- "sp-crypto-ec-utils 0.14.0",
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-debug-derive 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-crypto-ec-utils",
+ "sp-crypto-hashing",
+ "sp-debug-derive",
  "sp-externalities 0.29.0",
  "sp-genesis-builder 0.15.1",
  "sp-inherents 34.0.0",
@@ -9197,21 +9118,21 @@ dependencies = [
  "sp-staking 36.0.0",
  "sp-state-machine 0.43.0",
  "sp-statement-store",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
  "sp-storage 21.0.0",
  "sp-timestamp 34.0.0",
- "sp-tracing 17.0.1",
+ "sp-tracing",
  "sp-transaction-pool",
  "sp-transaction-storage-proof",
  "sp-trie 37.0.0",
  "sp-version 37.0.0",
- "sp-wasm-interface 21.0.1",
- "sp-weights 31.0.0",
+ "sp-wasm-interface",
+ "sp-weights",
  "staging-parachain-info",
  "staging-xcm 14.2.1",
  "staging-xcm-builder 17.0.4",
  "staging-xcm-executor 17.0.1",
- "substrate-bip39 0.6.0",
+ "substrate-bip39",
  "testnet-parachains-constants",
  "xcm-runtime-apis",
 ]
@@ -9234,7 +9155,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api 34.0.0",
- "sp-arithmetic 26.0.0",
+ "sp-arithmetic",
  "sp-block-builder",
  "sp-consensus-aura 0.40.0",
  "sp-consensus-grandpa",
@@ -9284,7 +9205,7 @@ dependencies = [
  "libc",
  "log",
  "polkavm-assembler 0.21.0",
- "polkavm-common 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "polkavm-common 0.21.0",
  "polkavm-linux-raw 0.21.0",
 ]
 
@@ -9353,8 +9274,9 @@ dependencies = [
 
 [[package]]
 name = "polkavm-common"
-version = "0.21.0"
-source = "git+https://github.com/paritytech/polkavm#d0a4f5d72cfc00fc4d847633e5d0f98cf31de7d4"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "538810ffdaa629113b9f436f43ba487a6cceacc04a769ac3cdcd32fcf87351cd"
 
 [[package]]
 name = "polkavm-derive"
@@ -9389,15 +9311,16 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47239245f87329541932c0d7fec750a66a75b13aa87dfe4fbfd637bab86ad387"
 dependencies = [
- "polkavm-derive-impl-macro 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "polkavm-derive-impl-macro 0.21.0",
 ]
 
 [[package]]
 name = "polkavm-derive"
-version = "0.21.0"
-source = "git+https://github.com/paritytech/polkavm#d0a4f5d72cfc00fc4d847633e5d0f98cf31de7d4"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e819eaea986d6a3de2a08840f0cc188db3c318b30f9bb1deb416d8c4beb2ed14"
 dependencies = [
- "polkavm-derive-impl-macro 0.21.0 (git+https://github.com/paritytech/polkavm)",
+ "polkavm-derive-impl-macro 0.22.0",
 ]
 
 [[package]]
@@ -9442,7 +9365,7 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24fd6c6215450c3e57511df5c38a82eb4bde208de15ee15046ac33852f3c3eaa"
 dependencies = [
- "polkavm-common 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "polkavm-common 0.21.0",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -9450,10 +9373,11 @@ dependencies = [
 
 [[package]]
 name = "polkavm-derive-impl"
-version = "0.21.0"
-source = "git+https://github.com/paritytech/polkavm#d0a4f5d72cfc00fc4d847633e5d0f98cf31de7d4"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "414507a0a7c9451cc81336ef1f5ccbab8fa4aeda402668735aa28331867bd3ef"
 dependencies = [
- "polkavm-common 0.21.0 (git+https://github.com/paritytech/polkavm)",
+ "polkavm-common 0.22.0",
  "proc-macro2",
  "quote",
  "syn 2.0.100",
@@ -9495,16 +9419,17 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36837f6b7edfd6f4498f8d25d81da16cf03bd6992c3e56f3d477dfc90f4fefca"
 dependencies = [
- "polkavm-derive-impl 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "polkavm-derive-impl 0.21.0",
  "syn 2.0.100",
 ]
 
 [[package]]
 name = "polkavm-derive-impl-macro"
-version = "0.21.0"
-source = "git+https://github.com/paritytech/polkavm#d0a4f5d72cfc00fc4d847633e5d0f98cf31de7d4"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad6a5df4cc6466a219386b04d8bd267ba772f9458a8e9aa7539757ca5b11e2aa"
 dependencies = [
- "polkavm-derive-impl 0.21.0 (git+https://github.com/paritytech/polkavm)",
+ "polkavm-derive-impl 0.22.0",
  "syn 2.0.100",
 ]
 
@@ -9549,22 +9474,23 @@ dependencies = [
  "hashbrown 0.14.5",
  "log",
  "object 0.36.7",
- "polkavm-common 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "polkavm-common 0.21.0",
  "regalloc2 0.9.3",
  "rustc-demangle",
 ]
 
 [[package]]
 name = "polkavm-linker"
-version = "0.21.0"
-source = "git+https://github.com/paritytech/polkavm#d0a4f5d72cfc00fc4d847633e5d0f98cf31de7d4"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9d349fb26ebfbf4b1794f08c045a543f8a6daf0878ce5b5c8b5ed06980a818"
 dependencies = [
  "dirs",
  "gimli 0.31.1",
  "hashbrown 0.14.5",
  "log",
  "object 0.36.7",
- "polkavm-common 0.21.0 (git+https://github.com/paritytech/polkavm)",
+ "polkavm-common 0.22.0",
  "regalloc2 0.9.3",
  "rustc-demangle",
 ]
@@ -9890,6 +9816,7 @@ checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
+ "serde",
  "zerocopy 0.8.24",
 ]
 
@@ -9929,6 +9856,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.2",
+ "serde",
 ]
 
 [[package]]
@@ -10147,23 +10075,6 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.1.0"
-source = "git+https://github.com/davxy/ring-proof?branch=locked#a24b371b8d51725ac2ce195aa3369b31df6c9873"
-dependencies = [
- "ark-ec",
- "ark-ff 0.4.2",
- "ark-poly",
- "ark-serialize 0.4.2",
- "ark-std 0.4.0",
- "ark-transcript 0.0.2 (git+https://github.com/w3f/ark-transcript?rev=288e49d)",
- "arrayvec 0.7.6",
- "blake2",
- "common",
- "fflonk",
-]
-
-[[package]]
-name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
@@ -10246,7 +10157,7 @@ dependencies = [
  "smallvec",
  "sp-core 34.0.0",
  "sp-runtime 39.0.5",
- "sp-weights 31.0.0",
+ "sp-weights",
  "staging-xcm 14.2.1",
  "staging-xcm-builder 17.0.4",
 ]
@@ -10399,7 +10310,7 @@ checksum = "822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c"
 dependencies = [
  "log",
  "once_cell",
- "ring 0.17.14",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -10457,7 +10368,7 @@ version = "0.103.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
 dependencies = [
- "ring 0.17.14",
+ "ring",
  "rustls-pki-types",
  "untrusted",
 ]
@@ -10540,7 +10451,7 @@ checksum = "b975ee3a95eaacb611e7b415737a7fa2db4d8ad7b880cc1b97371b04e95c7903"
 dependencies = [
  "log",
  "sp-core 34.0.0",
- "sp-wasm-interface 21.0.1",
+ "sp-wasm-interface",
  "thiserror 1.0.69",
 ]
 
@@ -10560,11 +10471,11 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-externalities 0.29.0",
  "sp-io 38.0.0",
- "sp-panic-handler 13.0.1",
+ "sp-panic-handler",
  "sp-runtime-interface 28.0.0",
  "sp-trie 37.0.0",
  "sp-version 37.0.0",
- "sp-wasm-interface 21.0.1",
+ "sp-wasm-interface",
  "tracing",
 ]
 
@@ -10577,7 +10488,7 @@ dependencies = [
  "polkavm 0.9.3",
  "sc-allocator",
  "sp-maybe-compressed-blob",
- "sp-wasm-interface 21.0.1",
+ "sp-wasm-interface",
  "thiserror 1.0.69",
  "wasm-instrument",
 ]
@@ -10591,7 +10502,7 @@ dependencies = [
  "log",
  "polkavm 0.9.3",
  "sc-executor-common",
- "sp-wasm-interface 21.0.1",
+ "sp-wasm-interface",
 ]
 
 [[package]]
@@ -10609,7 +10520,7 @@ dependencies = [
  "sc-allocator",
  "sc-executor-common",
  "sp-runtime-interface 28.0.0",
- "sp-wasm-interface 21.0.1",
+ "sp-wasm-interface",
  "wasmtime",
 ]
 
@@ -11445,7 +11356,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-runtime 39.0.5",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
  "ssz_rs",
  "ssz_rs_derive",
 ]
@@ -11465,11 +11376,11 @@ dependencies = [
  "scale-info",
  "serde",
  "snowbridge-beacon-primitives",
- "sp-arithmetic 26.0.0",
+ "sp-arithmetic",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-runtime 39.0.5",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
  "staging-xcm 14.2.1",
  "staging-xcm-builder 17.0.4",
 ]
@@ -11492,7 +11403,7 @@ dependencies = [
  "serde-big-array",
  "sp-io 38.0.0",
  "sp-runtime 39.0.5",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
 ]
 
 [[package]]
@@ -11533,7 +11444,7 @@ dependencies = [
  "snowbridge-core",
  "snowbridge-outbound-queue-merkle-tree",
  "sp-api 34.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
 ]
 
 [[package]]
@@ -11557,7 +11468,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-runtime 39.0.5",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
  "static_assertions",
 ]
 
@@ -11571,7 +11482,7 @@ dependencies = [
  "snowbridge-beacon-primitives",
  "snowbridge-core",
  "sp-core 34.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
 ]
 
 [[package]]
@@ -11597,7 +11508,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-runtime 39.0.5",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
  "staging-xcm 14.2.1",
  "staging-xcm-executor 17.0.1",
 ]
@@ -11612,7 +11523,7 @@ dependencies = [
  "snowbridge-beacon-primitives",
  "snowbridge-core",
  "sp-core 34.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
 ]
 
 [[package]]
@@ -11631,11 +11542,11 @@ dependencies = [
  "serde",
  "snowbridge-core",
  "snowbridge-outbound-queue-merkle-tree",
- "sp-arithmetic 26.0.0",
+ "sp-arithmetic",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-runtime 39.0.5",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
 ]
 
 [[package]]
@@ -11654,7 +11565,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-runtime 39.0.5",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
  "staging-xcm 14.2.1",
  "staging-xcm-executor 17.0.1",
 ]
@@ -11674,7 +11585,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-runtime 39.0.5",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
  "staging-xcm 14.2.1",
  "staging-xcm-executor 17.0.1",
 ]
@@ -11689,8 +11600,8 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "snowbridge-core",
- "sp-arithmetic 26.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-arithmetic",
+ "sp-std",
  "staging-xcm 14.2.1",
  "staging-xcm-builder 17.0.4",
  "staging-xcm-executor 17.0.1",
@@ -11737,7 +11648,7 @@ dependencies = [
  "parity-scale-codec",
  "snowbridge-core",
  "sp-api 34.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
  "staging-xcm 14.2.1",
 ]
 
@@ -11768,50 +11679,6 @@ dependencies = [
 
 [[package]]
 name = "sp-api"
-version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
-dependencies = [
- "docify",
- "hash-db",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-api-proc-macro 15.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-metadata-ir 0.6.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-state-machine 0.35.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-trie 29.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-version 29.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "sp-api"
-version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "docify",
- "hash-db",
- "log",
- "parity-scale-codec",
- "scale-info",
- "sp-api-proc-macro 15.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-metadata-ir 0.6.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-state-machine 0.35.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-trie 29.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-version 29.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "sp-api"
 version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbce492e0482134128b7729ea36f5ef1a9f9b4de2d48ff8dde7b5e464e28ce75"
@@ -11834,31 +11701,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-api-proc-macro"
-version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
+name = "sp-api"
+version = "36.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "541da427f47dfb97f3dd0556fa3272bdc5dfa0d4c1ad53a22670a9bae4db63d7"
 dependencies = [
- "Inflector",
- "blake2",
- "expander",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "sp-api-proc-macro"
-version = "15.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "Inflector",
- "blake2",
- "expander",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.100",
+ "docify",
+ "hash-db",
+ "log",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api-proc-macro 22.0.0",
+ "sp-core 36.1.0",
+ "sp-externalities 0.30.0",
+ "sp-metadata-ir 0.10.0",
+ "sp-runtime 41.1.0",
+ "sp-runtime-interface 29.0.1",
+ "sp-state-machine 0.45.0",
+ "sp-trie 39.1.0",
+ "sp-version 39.0.0",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -11877,27 +11739,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-application-crypto"
-version = "30.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
+name = "sp-api-proc-macro"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36334085c348bb507debd40e604f71194b1fc669eb6fec81aebef08eb3466f6c"
 dependencies = [
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
-]
-
-[[package]]
-name = "sp-application-crypto"
-version = "30.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
+ "Inflector",
+ "blake2",
+ "expander",
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -11914,38 +11767,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-arithmetic"
-version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
-dependencies = [
- "docify",
- "integer-sqrt",
- "num-traits",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "static_assertions",
-]
-
-[[package]]
-name = "sp-arithmetic"
-version = "23.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "docify",
- "integer-sqrt",
- "num-traits",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "static_assertions",
-]
-
-[[package]]
-name = "sp-arithmetic"
-version = "26.0.0"
+name = "sp-application-crypto"
+version = "40.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46d0d0a4c591c421d3231ddd5e27d828618c24456d51445d21a1f79fcee97c23"
+checksum = "ba375ab65a76f7413d1bfe48122fd347ce7bd2047e36ecbbd78f12f5adaed121"
+dependencies = [
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-core 36.1.0",
+ "sp-io 40.0.0",
+]
+
+[[package]]
+name = "sp-arithmetic"
+version = "26.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9971b30935cea3858664965039dabd80f67aca74cc6cc6dd42ff1ab14547bc53"
 dependencies = [
  "docify",
  "integer-sqrt",
@@ -11953,26 +11791,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "static_assertions",
-]
-
-[[package]]
-name = "sp-ark-bls12-381"
-version = "0.4.2"
-source = "git+https://github.com/paritytech/arkworks-substrate?rev=caa2eed#caa2eed74beb885dd07c7db5f916f2281dad818f"
-dependencies = [
- "ark-bls12-381-ext",
- "sp-crypto-ec-utils 0.10.0",
-]
-
-[[package]]
-name = "sp-ark-ed-on-bls12-381-bandersnatch"
-version = "0.4.2"
-source = "git+https://github.com/paritytech/arkworks-substrate?rev=caa2eed#caa2eed74beb885dd07c7db5f916f2281dad818f"
-dependencies = [
- "ark-ed-on-bls12-381-bandersnatch-ext",
- "sp-crypto-ec-utils 0.10.0",
 ]
 
 [[package]]
@@ -12001,38 +11820,6 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-aura"
-version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
-dependencies = [
- "async-trait",
- "parity-scale-codec",
- "scale-info",
- "sp-api 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-application-crypto 30.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-consensus-slots 0.32.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-inherents 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-timestamp 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
-]
-
-[[package]]
-name = "sp-consensus-aura"
-version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "async-trait",
- "parity-scale-codec",
- "scale-info",
- "sp-api 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-application-crypto 30.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-consensus-slots 0.32.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-inherents 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-timestamp 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
-]
-
-[[package]]
-name = "sp-consensus-aura"
 version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a8faaa05bbcb9c41f0cc535c4c1315abf6df472b53eae018678d1b4d811ac47"
@@ -12049,39 +11836,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-consensus-babe"
-version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
+name = "sp-consensus-aura"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4f3b3414e7620ad72d0000b520e0570dca38dc63e160c95164ff3f789020cc1"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
  "scale-info",
- "serde",
- "sp-api 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-application-crypto 30.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-consensus-slots 0.32.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-inherents 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-timestamp 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
-]
-
-[[package]]
-name = "sp-consensus-babe"
-version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "async-trait",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-api 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-application-crypto 30.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-consensus-slots 0.32.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-inherents 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-timestamp 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
+ "sp-api 36.0.1",
+ "sp-application-crypto 40.1.0",
+ "sp-consensus-slots 0.42.1",
+ "sp-inherents 36.0.0",
+ "sp-runtime 41.1.0",
+ "sp-timestamp 36.0.0",
 ]
 
 [[package]]
@@ -12104,6 +11872,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-consensus-babe"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b54310103ae4f0e3228e217e2a9ccaca0d7c3502d3aa276623febf4c722ca397"
+dependencies = [
+ "async-trait",
+ "parity-scale-codec",
+ "scale-info",
+ "serde",
+ "sp-api 36.0.1",
+ "sp-application-crypto 40.1.0",
+ "sp-consensus-slots 0.42.1",
+ "sp-core 36.1.0",
+ "sp-inherents 36.0.0",
+ "sp-runtime 41.1.0",
+ "sp-timestamp 36.0.0",
+]
+
+[[package]]
 name = "sp-consensus-beefy"
 version = "22.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12116,12 +11903,12 @@ dependencies = [
  "sp-api 34.0.0",
  "sp-application-crypto 38.0.0",
  "sp-core 34.0.0",
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-crypto-hashing",
  "sp-io 38.0.0",
  "sp-keystore 0.40.0",
  "sp-mmr-primitives",
  "sp-runtime 39.0.5",
- "sp-weights 31.0.0",
+ "sp-weights",
  "strum 0.26.3",
 ]
 
@@ -12157,28 +11944,6 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-slots"
-version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-timestamp 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
-]
-
-[[package]]
-name = "sp-consensus-slots"
-version = "0.32.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-timestamp 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
-]
-
-[[package]]
-name = "sp-consensus-slots"
 version = "0.40.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbafb7ed44f51c22fa277fb39b33dc601fa426133a8e2b53f3f46b10f07fba43"
@@ -12190,97 +11955,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-core"
-version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
+name = "sp-consensus-slots"
+version = "0.42.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc83d9e7b1d58e1d020c20d7208b00d21fa73dcf92721114eae432b9f01e62d5"
 dependencies = [
- "array-bytes",
- "bandersnatch_vrfs",
- "bitflags 1.3.2",
- "blake2",
- "bounded-collections",
- "bs58",
- "dyn-clonable",
- "ed25519-zebra",
- "futures",
- "hash-db",
- "hash256-std-hasher",
- "impl-serde 0.5.0",
- "itertools 0.11.0",
- "k256",
- "libsecp256k1",
- "log",
- "merlin",
- "parity-bip39",
  "parity-scale-codec",
- "parking_lot",
- "paste",
- "primitive-types 0.13.1",
- "rand 0.8.5",
  "scale-info",
- "schnorrkel",
- "secp256k1 0.28.2",
- "secrecy 0.8.0",
  "serde",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "ss58-registry",
- "substrate-bip39 0.4.7 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "thiserror 1.0.69",
- "tracing",
- "w3f-bls",
- "zeroize",
-]
-
-[[package]]
-name = "sp-core"
-version = "28.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "array-bytes",
- "bandersnatch_vrfs",
- "bitflags 1.3.2",
- "blake2",
- "bounded-collections",
- "bs58",
- "dyn-clonable",
- "ed25519-zebra",
- "futures",
- "hash-db",
- "hash256-std-hasher",
- "impl-serde 0.5.0",
- "itertools 0.11.0",
- "k256",
- "libsecp256k1",
- "log",
- "merlin",
- "parity-bip39",
- "parity-scale-codec",
- "parking_lot",
- "paste",
- "primitive-types 0.13.1",
- "rand 0.8.5",
- "scale-info",
- "schnorrkel",
- "secp256k1 0.28.2",
- "secrecy 0.8.0",
- "serde",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "ss58-registry",
- "substrate-bip39 0.4.7 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "thiserror 1.0.69",
- "tracing",
- "w3f-bls",
- "zeroize",
+ "sp-timestamp 36.0.0",
 ]
 
 [[package]]
@@ -12316,14 +11999,62 @@ dependencies = [
  "secp256k1 0.28.2",
  "secrecy 0.8.0",
  "serde",
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-debug-derive 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-crypto-hashing",
+ "sp-debug-derive",
  "sp-externalities 0.29.0",
  "sp-runtime-interface 28.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
  "sp-storage 21.0.0",
  "ss58-registry",
- "substrate-bip39 0.6.0",
+ "substrate-bip39",
+ "thiserror 1.0.69",
+ "tracing",
+ "w3f-bls",
+ "zeroize",
+]
+
+[[package]]
+name = "sp-core"
+version = "36.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cdbb58c21e6b27f2aadf3ff0c8b20a8ead13b9dfe63f46717fd59334517f3b4"
+dependencies = [
+ "ark-vrf",
+ "array-bytes",
+ "bitflags 1.3.2",
+ "blake2",
+ "bounded-collections",
+ "bs58",
+ "dyn-clonable",
+ "ed25519-zebra",
+ "futures",
+ "hash-db",
+ "hash256-std-hasher",
+ "impl-serde 0.5.0",
+ "itertools 0.11.0",
+ "k256",
+ "libsecp256k1",
+ "log",
+ "merlin",
+ "parity-bip39",
+ "parity-scale-codec",
+ "parking_lot",
+ "paste",
+ "primitive-types 0.13.1",
+ "rand 0.8.5",
+ "scale-info",
+ "schnorrkel",
+ "secp256k1 0.28.2",
+ "secrecy 0.8.0",
+ "serde",
+ "sp-crypto-hashing",
+ "sp-debug-derive",
+ "sp-externalities 0.30.0",
+ "sp-runtime-interface 29.0.1",
+ "sp-std",
+ "sp-storage 22.0.0",
+ "ss58-registry",
+ "substrate-bip39",
  "thiserror 1.0.69",
  "tracing",
  "w3f-bls",
@@ -12336,27 +12067,7 @@ version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f812cb2dff962eb378c507612a50f1c59f52d92eb97b710f35be3c2346a3cd7"
 dependencies = [
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "sp-crypto-ec-utils"
-version = "0.10.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#9be43c0abf0a02a28d8fd4bbe9cfaed17dfcf18c"
-dependencies = [
- "ark-bls12-377",
- "ark-bls12-377-ext",
- "ark-bls12-381",
- "ark-bls12-381-ext",
- "ark-bw6-761",
- "ark-bw6-761-ext",
- "ark-ec",
- "ark-ed-on-bls12-377",
- "ark-ed-on-bls12-377-ext",
- "ark-ed-on-bls12-381-bandersnatch",
- "ark-ed-on-bls12-381-bandersnatch-ext",
- "ark-scale",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
+ "sp-crypto-hashing",
 ]
 
 [[package]]
@@ -12367,14 +12078,14 @@ checksum = "2acb24f8a607a48a87f0ee4c090fc5d577eee49ff39ced6a3c491e06eca03c37"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-377-ext",
- "ark-bls12-381",
+ "ark-bls12-381 0.4.0",
  "ark-bls12-381-ext",
  "ark-bw6-761",
  "ark-bw6-761-ext",
- "ark-ec",
+ "ark-ec 0.4.2",
  "ark-ed-on-bls12-377",
  "ark-ed-on-bls12-377-ext",
- "ark-ed-on-bls12-381-bandersnatch",
+ "ark-ed-on-bls12-381-bandersnatch 0.4.0",
  "ark-ed-on-bls12-381-bandersnatch-ext",
  "ark-scale",
  "sp-runtime-interface 28.0.0",
@@ -12395,59 +12106,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-crypto-hashing"
-version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
-dependencies = [
- "blake2b_simd",
- "byteorder",
- "digest 0.10.7",
- "sha2 0.10.8",
- "sha3",
- "twox-hash",
-]
-
-[[package]]
-name = "sp-crypto-hashing"
-version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "blake2b_simd",
- "byteorder",
- "digest 0.10.7",
- "sha2 0.10.8",
- "sha3",
- "twox-hash",
-]
-
-[[package]]
 name = "sp-crypto-hashing-proc-macro"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b85d0f1f1e44bd8617eb2a48203ee854981229e3e79e6f468c7175d5fd37489b"
 dependencies = [
  "quote",
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "sp-crypto-hashing-proc-macro"
-version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
-dependencies = [
- "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "sp-crypto-hashing-proc-macro"
-version = "0.1.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "quote",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
+ "sp-crypto-hashing",
  "syn 2.0.100",
 ]
 
@@ -12463,66 +12128,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-debug-derive"
-version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "sp-debug-derive"
-version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "sp-debug-derive"
-version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#9be43c0abf0a02a28d8fd4bbe9cfaed17dfcf18c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "sp-externalities"
-version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
-dependencies = [
- "environmental",
- "parity-scale-codec",
- "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
-]
-
-[[package]]
-name = "sp-externalities"
-version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "environmental",
- "parity-scale-codec",
- "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
-]
-
-[[package]]
-name = "sp-externalities"
-version = "0.25.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#9be43c0abf0a02a28d8fd4bbe9cfaed17dfcf18c"
-dependencies = [
- "environmental",
- "parity-scale-codec",
- "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
-]
-
-[[package]]
 name = "sp-externalities"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12534,27 +12139,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-genesis-builder"
-version = "0.8.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
+name = "sp-externalities"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30cbf059dce180a8bf8b6c8b08b6290fa3d1c7f069a60f1df038ab5dd5fc0ba6"
 dependencies = [
+ "environmental",
  "parity-scale-codec",
- "scale-info",
- "serde_json",
- "sp-api 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
-]
-
-[[package]]
-name = "sp-genesis-builder"
-version = "0.8.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "parity-scale-codec",
- "scale-info",
- "serde_json",
- "sp-api 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
+ "sp-storage 22.0.0",
 ]
 
 [[package]]
@@ -12571,29 +12163,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-inherents"
-version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
+name = "sp-genesis-builder"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efb0d996dfce9afb8879bdfbba9cb9a7d06f29fda38168b91e90419b3b92c42e"
 dependencies = [
- "async-trait",
- "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "sp-inherents"
-version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "async-trait",
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "scale-info",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "thiserror 1.0.69",
+ "serde_json",
+ "sp-api 36.0.1",
+ "sp-runtime 41.1.0",
 ]
 
 [[package]]
@@ -12611,55 +12190,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-io"
-version = "30.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
+name = "sp-inherents"
+version = "36.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb09ff07946f3e1ecdd4bfb40b2cceba60188215ceb941b5b07230294d7aee1"
 dependencies = [
- "bytes",
- "docify",
- "ed25519-dalek",
- "libsecp256k1",
- "log",
+ "async-trait",
+ "impl-trait-for-tuples",
  "parity-scale-codec",
- "polkavm-derive 0.18.0",
- "rustversion",
- "secp256k1 0.28.2",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-keystore 0.34.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-state-machine 0.35.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-trie 29.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "tracing",
- "tracing-core",
-]
-
-[[package]]
-name = "sp-io"
-version = "30.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "bytes",
- "docify",
- "ed25519-dalek",
- "libsecp256k1",
- "log",
- "parity-scale-codec",
- "polkavm-derive 0.18.0",
- "rustversion",
- "secp256k1 0.28.2",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-crypto-hashing 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-keystore 0.34.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-runtime-interface 24.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-state-machine 0.35.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-trie 29.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "tracing",
- "tracing-core",
+ "scale-info",
+ "sp-runtime 41.1.0",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -12678,25 +12219,42 @@ dependencies = [
  "rustversion",
  "secp256k1 0.28.2",
  "sp-core 34.0.0",
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-crypto-hashing",
  "sp-externalities 0.29.0",
  "sp-keystore 0.40.0",
  "sp-runtime-interface 28.0.0",
  "sp-state-machine 0.43.0",
- "sp-tracing 17.0.1",
+ "sp-tracing",
  "sp-trie 37.0.0",
  "tracing",
  "tracing-core",
 ]
 
 [[package]]
-name = "sp-keyring"
-version = "31.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
+name = "sp-io"
+version = "40.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5d93ea3512cf361577719bab161e46eb04d3abd8563e32bdf5df4a42aea0ba"
 dependencies = [
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "strum 0.26.3",
+ "bytes",
+ "docify",
+ "ed25519-dalek",
+ "libsecp256k1",
+ "log",
+ "parity-scale-codec",
+ "polkavm-derive 0.18.0",
+ "rustversion",
+ "secp256k1 0.28.2",
+ "sp-core 36.1.0",
+ "sp-crypto-hashing",
+ "sp-externalities 0.30.0",
+ "sp-keystore 0.42.0",
+ "sp-runtime-interface 29.0.1",
+ "sp-state-machine 0.45.0",
+ "sp-tracing",
+ "sp-trie 39.1.0",
+ "tracing",
+ "tracing-core",
 ]
 
 [[package]]
@@ -12711,25 +12269,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-keystore"
-version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
+name = "sp-keyring"
+version = "41.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c601d506585c0bcee79dbde401251b127af5f04c7373fc3cf7d6a6b7f6b970a3"
 dependencies = [
- "parity-scale-codec",
- "parking_lot",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
-]
-
-[[package]]
-name = "sp-keystore"
-version = "0.34.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "parity-scale-codec",
- "parking_lot",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
+ "sp-core 36.1.0",
+ "sp-runtime 41.1.0",
+ "strum 0.26.3",
 ]
 
 [[package]]
@@ -12745,6 +12292,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "sp-keystore"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45f893398a5330e28f219662c7a0afa174fb068d8f82d2a9990016c4b0bc4369"
+dependencies = [
+ "parity-scale-codec",
+ "parking_lot",
+ "sp-core 36.1.0",
+ "sp-externalities 0.30.0",
+]
+
+[[package]]
 name = "sp-maybe-compressed-blob"
 version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12756,31 +12315,22 @@ dependencies = [
 
 [[package]]
 name = "sp-metadata-ir"
-version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
-dependencies = [
- "frame-metadata 20.0.0",
- "parity-scale-codec",
- "scale-info",
-]
-
-[[package]]
-name = "sp-metadata-ir"
-version = "0.6.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "frame-metadata 20.0.0",
- "parity-scale-codec",
- "scale-info",
-]
-
-[[package]]
-name = "sp-metadata-ir"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a616fa51350b35326682a472ee8e6ba742fdacb18babac38ecd46b3e05ead869"
 dependencies = [
  "frame-metadata 16.0.0",
+ "parity-scale-codec",
+ "scale-info",
+]
+
+[[package]]
+name = "sp-metadata-ir"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d1db25e362edbf5531b427d4bdfc2562bec6a031c3eb2a9145c0a0a01a572d"
+dependencies = [
+ "frame-metadata 20.0.0",
  "parity-scale-codec",
  "scale-info",
 ]
@@ -12810,7 +12360,7 @@ dependencies = [
  "serde",
  "sp-api 34.0.0",
  "sp-core 34.0.0",
- "sp-debug-derive 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-debug-derive",
  "sp-runtime 39.0.5",
  "thiserror 1.0.69",
 ]
@@ -12824,7 +12374,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-arithmetic 26.0.0",
+ "sp-arithmetic",
  "sp-core 34.0.0",
  "sp-runtime 39.0.5",
 ]
@@ -12842,88 +12392,12 @@ dependencies = [
 
 [[package]]
 name = "sp-panic-handler"
-version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
-dependencies = [
- "backtrace",
- "regex",
-]
-
-[[package]]
-name = "sp-panic-handler"
-version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "backtrace",
- "regex",
-]
-
-[[package]]
-name = "sp-panic-handler"
-version = "13.0.1"
+version = "13.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81478b3740b357fa0ea10fcdc1ee02ebae7734e50f80342c4743476d9f78eeea"
+checksum = "c8b52e69a577cbfdea62bfaf16f59eb884422ce98f78b5cd8d9bf668776bced1"
 dependencies = [
  "backtrace",
  "regex",
-]
-
-[[package]]
-name = "sp-runtime"
-version = "31.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
-dependencies = [
- "binary-merkle-tree 13.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "docify",
- "either",
- "hash256-std-hasher",
- "impl-trait-for-tuples",
- "log",
- "num-traits",
- "parity-scale-codec",
- "paste",
- "rand 0.8.5",
- "scale-info",
- "serde",
- "simple-mermaid",
- "sp-application-crypto 30.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-arithmetic 23.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-trie 29.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-weights 27.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "tracing",
- "tuplex",
-]
-
-[[package]]
-name = "sp-runtime"
-version = "31.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "binary-merkle-tree 13.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "docify",
- "either",
- "hash256-std-hasher",
- "impl-trait-for-tuples",
- "log",
- "num-traits",
- "parity-scale-codec",
- "paste",
- "rand 0.8.5",
- "scale-info",
- "serde",
- "simple-mermaid",
- "sp-application-crypto 30.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-arithmetic 23.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-trie 29.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-weights 27.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "tracing",
- "tuplex",
 ]
 
 [[package]]
@@ -12945,69 +12419,42 @@ dependencies = [
  "serde",
  "simple-mermaid",
  "sp-application-crypto 38.0.0",
- "sp-arithmetic 26.0.0",
+ "sp-arithmetic",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sp-weights 31.0.0",
+ "sp-std",
+ "sp-weights",
  "tracing",
 ]
 
 [[package]]
-name = "sp-runtime-interface"
-version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
+name = "sp-runtime"
+version = "41.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3864101a28faba3d8eca026e3f56ea20dd1d979ce1bcc20152e86c9d82be52bf"
 dependencies = [
- "bytes",
+ "binary-merkle-tree 16.0.0",
+ "docify",
+ "either",
+ "hash256-std-hasher",
  "impl-trait-for-tuples",
+ "log",
+ "num-traits",
  "parity-scale-codec",
- "polkavm-derive 0.18.0",
- "primitive-types 0.13.1",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-runtime-interface-proc-macro 17.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "static_assertions",
-]
-
-[[package]]
-name = "sp-runtime-interface"
-version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "bytes",
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "polkavm-derive 0.18.0",
- "primitive-types 0.13.1",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-runtime-interface-proc-macro 17.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "static_assertions",
-]
-
-[[package]]
-name = "sp-runtime-interface"
-version = "24.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#9be43c0abf0a02a28d8fd4bbe9cfaed17dfcf18c"
-dependencies = [
- "bytes",
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "polkavm-derive 0.18.0",
- "primitive-types 0.13.1",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk)",
- "sp-runtime-interface-proc-macro 17.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
- "sp-storage 19.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
- "sp-tracing 16.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
- "sp-wasm-interface 20.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
- "static_assertions",
+ "paste",
+ "rand 0.8.5",
+ "scale-info",
+ "serde",
+ "simple-mermaid",
+ "sp-application-crypto 40.1.0",
+ "sp-arithmetic",
+ "sp-core 36.1.0",
+ "sp-io 40.0.0",
+ "sp-std",
+ "sp-trie 39.1.0",
+ "sp-weights",
+ "tracing",
+ "tuplex",
 ]
 
 [[package]]
@@ -13022,51 +12469,32 @@ dependencies = [
  "polkavm-derive 0.9.1",
  "primitive-types 0.12.2",
  "sp-externalities 0.29.0",
- "sp-runtime-interface-proc-macro 18.0.0",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-runtime-interface-proc-macro",
+ "sp-std",
  "sp-storage 21.0.0",
- "sp-tracing 17.0.1",
- "sp-wasm-interface 21.0.1",
+ "sp-tracing",
+ "sp-wasm-interface",
  "static_assertions",
 ]
 
 [[package]]
-name = "sp-runtime-interface-proc-macro"
-version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
+name = "sp-runtime-interface"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e99db36a7aff44c335f5d5b36c182a3e0cac61de2fefbe2eeac6af5fb13f63bf"
 dependencies = [
- "Inflector",
- "expander",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "sp-runtime-interface-proc-macro"
-version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "Inflector",
- "expander",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "sp-runtime-interface-proc-macro"
-version = "17.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#9be43c0abf0a02a28d8fd4bbe9cfaed17dfcf18c"
-dependencies = [
- "Inflector",
- "expander",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn 2.0.100",
+ "bytes",
+ "impl-trait-for-tuples",
+ "parity-scale-codec",
+ "polkavm-derive 0.18.0",
+ "primitive-types 0.13.1",
+ "sp-externalities 0.30.0",
+ "sp-runtime-interface-proc-macro",
+ "sp-std",
+ "sp-storage 22.0.0",
+ "sp-tracing",
+ "sp-wasm-interface",
+ "static_assertions",
 ]
 
 [[package]]
@@ -13100,32 +12528,6 @@ dependencies = [
 
 [[package]]
 name = "sp-staking"
-version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
-dependencies = [
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
-]
-
-[[package]]
-name = "sp-staking"
-version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
-]
-
-[[package]]
-name = "sp-staking"
 version = "34.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "143a764cacbab58347d8b2fd4c8909031fb0888d7b02a0ec9fa44f81f780d732"
@@ -13153,43 +12555,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-state-machine"
-version = "0.35.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
+name = "sp-staking"
+version = "38.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8f9c0a32836e3c8842b0aec0813077654885d45d83b618210fbb730ea63545"
 dependencies = [
- "hash-db",
- "log",
+ "impl-trait-for-tuples",
  "parity-scale-codec",
- "parking_lot",
- "rand 0.8.5",
- "smallvec",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-panic-handler 13.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-trie 29.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "thiserror 1.0.69",
- "tracing",
- "trie-db 0.30.0",
-]
-
-[[package]]
-name = "sp-state-machine"
-version = "0.35.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "hash-db",
- "log",
- "parity-scale-codec",
- "parking_lot",
- "rand 0.8.5",
- "smallvec",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-panic-handler 13.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-trie 29.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "thiserror 1.0.69",
- "tracing",
- "trie-db 0.30.0",
+ "scale-info",
+ "serde",
+ "sp-core 36.1.0",
+ "sp-runtime 41.1.0",
 ]
 
 [[package]]
@@ -13206,11 +12582,32 @@ dependencies = [
  "smallvec",
  "sp-core 34.0.0",
  "sp-externalities 0.29.0",
- "sp-panic-handler 13.0.1",
+ "sp-panic-handler",
  "sp-trie 37.0.0",
  "thiserror 1.0.69",
  "tracing",
  "trie-db 0.29.1",
+]
+
+[[package]]
+name = "sp-state-machine"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206508475c01ae2e14f171d35d7fc3eaa7278140d7940416591d49a784792ed6"
+dependencies = [
+ "hash-db",
+ "log",
+ "parity-scale-codec",
+ "parking_lot",
+ "rand 0.8.5",
+ "smallvec",
+ "sp-core 36.1.0",
+ "sp-externalities 0.30.0",
+ "sp-panic-handler",
+ "sp-trie 39.1.0",
+ "thiserror 1.0.69",
+ "tracing",
+ "trie-db 0.30.0",
 ]
 
 [[package]]
@@ -13230,7 +12627,7 @@ dependencies = [
  "sp-api 34.0.0",
  "sp-application-crypto 38.0.0",
  "sp-core 34.0.0",
- "sp-crypto-hashing 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-crypto-hashing",
  "sp-externalities 0.29.0",
  "sp-runtime 39.0.5",
  "sp-runtime-interface 28.0.0",
@@ -13245,57 +12642,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12f8ee986414b0a9ad741776762f4083cd3a5128449b982a3919c4df36874834"
 
 [[package]]
-name = "sp-std"
-version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
-
-[[package]]
-name = "sp-std"
-version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-
-[[package]]
-name = "sp-std"
-version = "14.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#9be43c0abf0a02a28d8fd4bbe9cfaed17dfcf18c"
-
-[[package]]
-name = "sp-storage"
-version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
-dependencies = [
- "impl-serde 0.5.0",
- "parity-scale-codec",
- "ref-cast",
- "serde",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
-]
-
-[[package]]
-name = "sp-storage"
-version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "impl-serde 0.5.0",
- "parity-scale-codec",
- "ref-cast",
- "serde",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
-]
-
-[[package]]
-name = "sp-storage"
-version = "19.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#9be43c0abf0a02a28d8fd4bbe9cfaed17dfcf18c"
-dependencies = [
- "impl-serde 0.5.0",
- "parity-scale-codec",
- "ref-cast",
- "serde",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk)",
-]
-
-[[package]]
 name = "sp-storage"
 version = "21.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13305,31 +12651,20 @@ dependencies = [
  "parity-scale-codec",
  "ref-cast",
  "serde",
- "sp-debug-derive 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-debug-derive",
 ]
 
 [[package]]
-name = "sp-timestamp"
-version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
+name = "sp-storage"
+version = "22.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee3b70ca340e41cde9d2e069d354508a6e37a6573d66f7cc38f11549002f64ec"
 dependencies = [
- "async-trait",
+ "impl-serde 0.5.0",
  "parity-scale-codec",
- "sp-inherents 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "sp-timestamp"
-version = "26.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "async-trait",
- "parity-scale-codec",
- "sp-inherents 26.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "thiserror 1.0.69",
+ "ref-cast",
+ "serde",
+ "sp-debug-derive",
 ]
 
 [[package]]
@@ -13346,43 +12681,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-tracing"
-version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
-dependencies = [
- "parity-scale-codec",
- "tracing",
- "tracing-core",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "sp-tracing"
-version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "parity-scale-codec",
- "tracing",
- "tracing-core",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "sp-tracing"
-version = "16.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#9be43c0abf0a02a28d8fd4bbe9cfaed17dfcf18c"
-dependencies = [
- "parity-scale-codec",
- "tracing",
- "tracing-core",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "sp-tracing"
-version = "17.0.1"
+name = "sp-timestamp"
+version = "36.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf641a1d17268c8fcfdb8e0fa51a79c2d4222f4cfda5f3944dbdbc384dced8d5"
+checksum = "176c77326c15425a15e085261161a9435f9a3c0d4bf61dae6dccf05b957a51c6"
+dependencies = [
+ "async-trait",
+ "parity-scale-codec",
+ "sp-inherents 36.0.0",
+ "sp-runtime 41.1.0",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "sp-tracing"
+version = "17.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6147a5b8c98b9ed4bf99dc033fab97a468b4645515460974c8784daeb7c35433"
 dependencies = [
  "parity-scale-codec",
  "tracing",
@@ -13417,50 +12732,6 @@ dependencies = [
 
 [[package]]
 name = "sp-trie"
-version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
-dependencies = [
- "ahash 0.8.11",
- "hash-db",
- "memory-db",
- "nohash-hasher",
- "parity-scale-codec",
- "parking_lot",
- "rand 0.8.5",
- "scale-info",
- "schnellru",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "thiserror 1.0.69",
- "tracing",
- "trie-db 0.30.0",
- "trie-root",
-]
-
-[[package]]
-name = "sp-trie"
-version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "ahash 0.8.11",
- "hash-db",
- "memory-db",
- "nohash-hasher",
- "parity-scale-codec",
- "parking_lot",
- "rand 0.8.5",
- "scale-info",
- "schnellru",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-externalities 0.25.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "thiserror 1.0.69",
- "tracing",
- "trie-db 0.30.0",
- "trie-root",
-]
-
-[[package]]
-name = "sp-trie"
 version = "37.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6282aef9f4b6ecd95a67a45bcdb67a71f4a4155c09a53c10add4ffe823db18cd"
@@ -13484,37 +12755,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-version"
-version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
+name = "sp-trie"
+version = "39.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a555bf4c42ca89e2e7bf2f11308806dad13cdbd7f8fd60cf2649f12b6ee809bf"
 dependencies = [
- "impl-serde 0.5.0",
+ "ahash 0.8.11",
+ "hash-db",
+ "memory-db",
+ "nohash-hasher",
  "parity-scale-codec",
- "parity-wasm",
+ "parking_lot",
+ "rand 0.8.5",
  "scale-info",
- "serde",
- "sp-crypto-hashing-proc-macro 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-version-proc-macro 13.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
+ "schnellru",
+ "sp-core 36.1.0",
+ "sp-externalities 0.30.0",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "sp-version"
-version = "29.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "impl-serde 0.5.0",
- "parity-scale-codec",
- "parity-wasm",
- "scale-info",
- "serde",
- "sp-crypto-hashing-proc-macro 0.1.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-std 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-version-proc-macro 13.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "thiserror 1.0.69",
+ "tracing",
+ "trie-db 0.30.0",
+ "trie-root",
 ]
 
 [[package]]
@@ -13528,35 +12788,29 @@ dependencies = [
  "parity-wasm",
  "scale-info",
  "serde",
- "sp-crypto-hashing-proc-macro 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-crypto-hashing-proc-macro",
  "sp-runtime 39.0.5",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
  "sp-version-proc-macro 14.0.0",
  "thiserror 1.0.69",
 ]
 
 [[package]]
-name = "sp-version-proc-macro"
-version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
+name = "sp-version"
+version = "39.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd736a15ff2ea0a67c5a3bbdfd842d88f11f0774d7701a8d8a316f8deba276c5"
 dependencies = [
+ "impl-serde 0.5.0",
  "parity-scale-codec",
- "proc-macro-warning",
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "sp-version-proc-macro"
-version = "13.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "parity-scale-codec",
- "proc-macro-warning",
- "proc-macro2",
- "quote",
- "syn 2.0.100",
+ "parity-wasm",
+ "scale-info",
+ "serde",
+ "sp-crypto-hashing-proc-macro",
+ "sp-runtime 41.1.0",
+ "sp-std",
+ "sp-version-proc-macro 15.0.0",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -13572,36 +12826,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-wasm-interface"
-version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
+name = "sp-version-proc-macro"
+version = "15.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54cabc8279e835cd9c608d70cb00e693bddec94fe8478e9f3104dad1da5f93ca"
 dependencies = [
- "anyhow",
- "impl-trait-for-tuples",
- "log",
  "parity-scale-codec",
-]
-
-[[package]]
-name = "sp-wasm-interface"
-version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "anyhow",
- "impl-trait-for-tuples",
- "log",
- "parity-scale-codec",
-]
-
-[[package]]
-name = "sp-wasm-interface"
-version = "20.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk#9be43c0abf0a02a28d8fd4bbe9cfaed17dfcf18c"
-dependencies = [
- "anyhow",
- "impl-trait-for-tuples",
- "log",
- "parity-scale-codec",
+ "proc-macro-warning",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
 ]
 
 [[package]]
@@ -13619,45 +12853,17 @@ dependencies = [
 
 [[package]]
 name = "sp-weights"
-version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
-dependencies = [
- "bounded-collections",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "smallvec",
- "sp-arithmetic 23.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
-]
-
-[[package]]
-name = "sp-weights"
-version = "27.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "bounded-collections",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "smallvec",
- "sp-arithmetic 23.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-debug-derive 14.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
-]
-
-[[package]]
-name = "sp-weights"
-version = "31.0.0"
+version = "31.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93cdaf72a1dad537bbb130ba4d47307ebe5170405280ed1aa31fa712718a400e"
+checksum = "515aa194eabac059041df2dbee75b059b99981213ec680e9de85b45b6988346a"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
  "scale-info",
  "serde",
  "smallvec",
- "sp-arithmetic 26.0.0",
- "sp-debug-derive 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-arithmetic",
+ "sp-debug-derive",
 ]
 
 [[package]]
@@ -13736,48 +12942,6 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm"
-version = "7.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
-dependencies = [
- "array-bytes",
- "bounded-collections",
- "derive-where",
- "environmental",
- "frame-support 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "hex-literal 0.4.1",
- "impl-trait-for-tuples",
- "log",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-weights 27.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "xcm-procedural 7.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
-]
-
-[[package]]
-name = "staging-xcm"
-version = "7.0.1"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "array-bytes",
- "bounded-collections",
- "derive-where",
- "environmental",
- "frame-support 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "hex-literal 0.4.1",
- "impl-trait-for-tuples",
- "log",
- "parity-scale-codec",
- "scale-info",
- "serde",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-weights 27.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "xcm-procedural 7.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
-]
-
-[[package]]
-name = "staging-xcm"
 version = "14.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "250c5290c308d1f462403dc4e7926976727917e98a196de1ea4a49c86341f21c"
@@ -13792,56 +12956,30 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-runtime 39.0.5",
- "sp-weights 31.0.0",
+ "sp-weights",
  "xcm-procedural 10.1.0",
 ]
 
 [[package]]
-name = "staging-xcm-builder"
-version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
+name = "staging-xcm"
+version = "16.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dead7481ba2dec11b0df89745cef3a76f3eef9c9df20155426cd7e9651b4c799"
 dependencies = [
+ "array-bytes",
+ "bounded-collections",
+ "derive-where",
  "environmental",
- "frame-support 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "frame-system 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
+ "frame-support 40.1.0",
+ "hex-literal 0.4.1",
  "impl-trait-for-tuples",
- "pallet-asset-conversion 10.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "pallet-transaction-payment 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
+ "log",
  "parity-scale-codec",
- "polkadot-parachain-primitives 6.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
  "scale-info",
- "sp-arithmetic 23.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-weights 27.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "staging-xcm 7.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "staging-xcm-executor 7.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "tracing",
-]
-
-[[package]]
-name = "staging-xcm-builder"
-version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "environmental",
- "frame-support 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "frame-system 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "impl-trait-for-tuples",
- "pallet-asset-conversion 10.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "pallet-transaction-payment 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "parity-scale-codec",
- "polkadot-parachain-primitives 6.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "scale-info",
- "sp-arithmetic 23.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-weights 27.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "staging-xcm 7.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "staging-xcm-executor 7.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "tracing",
+ "serde",
+ "sp-runtime 41.1.0",
+ "sp-weights",
+ "xcm-procedural 11.0.2",
 ]
 
 [[package]]
@@ -13859,51 +12997,36 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-parachain-primitives 14.0.0",
  "scale-info",
- "sp-arithmetic 26.0.0",
+ "sp-arithmetic",
  "sp-io 38.0.0",
  "sp-runtime 39.0.5",
- "sp-weights 31.0.0",
+ "sp-weights",
  "staging-xcm 14.2.1",
  "staging-xcm-executor 17.0.1",
 ]
 
 [[package]]
-name = "staging-xcm-executor"
-version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
+name = "staging-xcm-builder"
+version = "20.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e041eaa60fc0df3dbaa5779959f5eaac9c1b81d045a5a1792479e46dfd31f028"
 dependencies = [
  "environmental",
- "frame-benchmarking 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "frame-support 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
+ "frame-support 40.1.0",
+ "frame-system 40.1.0",
  "impl-trait-for-tuples",
+ "pallet-asset-conversion 22.0.0",
+ "pallet-transaction-payment 40.0.0",
  "parity-scale-codec",
+ "polkadot-parachain-primitives 16.1.0",
  "scale-info",
- "sp-arithmetic 23.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "sp-weights 27.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "staging-xcm 7.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da)",
- "tracing",
-]
-
-[[package]]
-name = "staging-xcm-executor"
-version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "environmental",
- "frame-benchmarking 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "frame-support 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "impl-trait-for-tuples",
- "parity-scale-codec",
- "scale-info",
- "sp-arithmetic 23.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-core 28.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-io 30.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-runtime 31.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "sp-weights 27.0.0 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
- "staging-xcm 7.0.1 (git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a)",
+ "sp-arithmetic",
+ "sp-core 36.1.0",
+ "sp-io 40.0.0",
+ "sp-runtime 41.1.0",
+ "sp-weights",
+ "staging-xcm 16.1.0",
+ "staging-xcm-executor 19.1.0",
  "tracing",
 ]
 
@@ -13919,12 +13042,33 @@ dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
  "scale-info",
- "sp-arithmetic 26.0.0",
+ "sp-arithmetic",
  "sp-core 34.0.0",
  "sp-io 38.0.0",
  "sp-runtime 39.0.5",
- "sp-weights 31.0.0",
+ "sp-weights",
  "staging-xcm 14.2.1",
+ "tracing",
+]
+
+[[package]]
+name = "staging-xcm-executor"
+version = "19.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad6d7cc19f02e4c088c2719fe11f22216041909d6a6ab130c71e8d25818d7768"
+dependencies = [
+ "environmental",
+ "frame-benchmarking 40.0.0",
+ "frame-support 40.1.0",
+ "impl-trait-for-tuples",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-arithmetic",
+ "sp-core 36.1.0",
+ "sp-io 40.0.0",
+ "sp-runtime 41.1.0",
+ "sp-weights",
+ "staging-xcm 16.1.0",
  "tracing",
 ]
 
@@ -14004,30 +13148,6 @@ dependencies = [
 
 [[package]]
 name = "substrate-bip39"
-version = "0.4.7"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
-dependencies = [
- "hmac 0.12.1",
- "pbkdf2",
- "schnorrkel",
- "sha2 0.10.8",
- "zeroize",
-]
-
-[[package]]
-name = "substrate-bip39"
-version = "0.4.7"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "hmac 0.12.1",
- "pbkdf2",
- "schnorrkel",
- "sha2 0.10.8",
- "zeroize",
-]
-
-[[package]]
-name = "substrate-bip39"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca58ffd742f693dc13d69bdbb2e642ae239e0053f6aab3b104252892f856700a"
@@ -14055,7 +13175,8 @@ dependencies = [
 [[package]]
 name = "substrate-build-script-utils"
 version = "11.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b285e7d183a32732fdc119f3d81b7915790191fad602b7c709ef247073c77a2e"
 
 [[package]]
 name = "substrate-wasm-builder"
@@ -14293,6 +13414,18 @@ name = "syn-solidity"
 version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4560533fbd6914b94a8fb5cc803ed6801c3455668db3b810702c57612bac9412"
+dependencies = [
+ "paste",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "syn-solidity"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34c9c96de1f835488c1501092847b522be88c9ac6fb0d4c0fbea92992324c8f4"
 dependencies = [
  "paste",
  "proc-macro2",
@@ -14944,11 +14077,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70a3028804c8bbae2a97a15b71ffc0e308c4b01a520994aafa77d56e94e19024"
 dependencies = [
  "ark-bls12-377",
- "ark-bls12-381",
- "ark-ec",
+ "ark-bls12-381 0.4.0",
+ "ark-ec 0.4.2",
  "ark-ff 0.4.2",
  "ark-serialize 0.4.2",
- "ark-serialize-derive",
+ "ark-serialize-derive 0.4.2",
  "arrayref",
  "constcat",
  "digest 0.10.7",
@@ -14959,6 +14092,52 @@ dependencies = [
  "sha3",
  "thiserror 1.0.69",
  "zeroize",
+]
+
+[[package]]
+name = "w3f-pcs"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbe7a8d5c914b69392ab3b267f679a2e546fe29afaddce47981772ac71bd02e1"
+dependencies = [
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-poly 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "merlin",
+]
+
+[[package]]
+name = "w3f-plonk-common"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aca389e494fe08c5c108b512e2328309036ee1c0bc7bdfdb743fef54d448c8c"
+dependencies = [
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-poly 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "getrandom_or_panic",
+ "rand_core 0.6.4",
+ "w3f-pcs",
+]
+
+[[package]]
+name = "w3f-ring-proof"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a639379402ad51504575dbd258740383291ac8147d3b15859bdf1ea48c677de"
+dependencies = [
+ "ark-ec 0.5.0",
+ "ark-ff 0.5.0",
+ "ark-poly 0.5.0",
+ "ark-serialize 0.5.0",
+ "ark-std 0.5.0",
+ "ark-transcript",
+ "w3f-pcs",
+ "w3f-plonk-common",
 ]
 
 [[package]]
@@ -15419,7 +14598,7 @@ dependencies = [
  "smallvec",
  "sp-core 34.0.0",
  "sp-runtime 39.0.5",
- "sp-weights 31.0.0",
+ "sp-weights",
  "staging-xcm 14.2.1",
  "staging-xcm-builder 17.0.4",
 ]
@@ -15858,31 +15037,21 @@ dependencies = [
 
 [[package]]
 name = "xcm-procedural"
-version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=28a7ae71cc0eac747bf346804279217a68f700da#28a7ae71cc0eac747bf346804279217a68f700da"
-dependencies = [
- "Inflector",
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "xcm-procedural"
-version = "7.0.0"
-source = "git+https://github.com/paritytech/polkadot-sdk?rev=f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a#f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"
-dependencies = [
- "Inflector",
- "proc-macro2",
- "quote",
- "syn 2.0.100",
-]
-
-[[package]]
-name = "xcm-procedural"
 version = "10.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87fb4f14094d65c500a59bcf540cf42b99ee82c706edd6226a92e769ad60563e"
+dependencies = [
+ "Inflector",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "xcm-procedural"
+version = "11.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d3d21c65cbf847ae0b1a8e6411b614d269d3108c6c649b039bffcf225e89aa4"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -15900,7 +15069,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-api 34.0.0",
- "sp-weights 31.0.0",
+ "sp-weights",
  "staging-xcm 14.2.1",
  "staging-xcm-executor 17.0.1",
 ]
@@ -15922,7 +15091,7 @@ dependencies = [
  "scale-info",
  "sp-io 38.0.0",
  "sp-runtime 39.0.5",
- "sp-std 14.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sp-std",
  "staging-xcm 14.2.1",
  "staging-xcm-builder 17.0.4",
  "staging-xcm-executor 17.0.1",

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -46,10 +46,10 @@ crossterm = "0.28.1"
 itertools = "0.13.0"
 alloy-json-abi = "0.8.20"
 
-polkavm-linker = { git = "https://github.com/paritytech/polkavm" }
+polkavm-linker = "0.22.0"
 
 contract-metadata = { version = "6.0.0-alpha", path = "../metadata" }
-ink_metadata = { git = "https://github.com/use-ink/ink", branch = "master", default-features = false, features = ["std", "derive"] }
+ink_metadata = { git = "https://github.com/use-ink/ink", branch = "alex/update-dependencies", default-features = false, features = ["std", "derive"] }
 sha3 = "0.10.8"
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -49,7 +49,7 @@ alloy-json-abi = "0.8.20"
 polkavm-linker = "0.22.0"
 
 contract-metadata = { version = "6.0.0-alpha", path = "../metadata" }
-ink_metadata = { git = "https://github.com/use-ink/ink", branch = "alex/update-dependencies", default-features = false, features = ["std", "derive"] }
+ink_metadata = { git = "https://github.com/use-ink/ink", branch = "master", default-features = false, features = ["std", "derive"] }
 sha3 = "0.10.8"
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/build/templates/new/_Cargo.toml
+++ b/crates/build/templates/new/_Cargo.toml
@@ -5,10 +5,10 @@ authors = ["[your_name] <[your_email]>"]
 edition = "2021"
 
 [dependencies]
-ink = { git = "https://github.com/use-ink/ink", branch = "alex/update-dependencies", default-features = false, features = ["unstable-hostfn"] }
+ink = { git = "https://github.com/use-ink/ink", branch = "master", default-features = false, features = ["unstable-hostfn"] }
 
 [dev-dependencies]
-ink_e2e = { git = "https://github.com/use-ink/ink", branch = "alex/update-dependencies" }
+ink_e2e = { git = "https://github.com/use-ink/ink", branch = "master" }
 
 [lib]
 path = "lib.rs"

--- a/crates/build/templates/new/_Cargo.toml
+++ b/crates/build/templates/new/_Cargo.toml
@@ -5,10 +5,10 @@ authors = ["[your_name] <[your_email]>"]
 edition = "2021"
 
 [dependencies]
-ink = { git = "https://github.com/use-ink/ink", branch = "master", default-features = false, features = ["unstable-hostfn"] }
+ink = { git = "https://github.com/use-ink/ink", branch = "alex/update-dependencies", default-features = false, features = ["unstable-hostfn"] }
 
 [dev-dependencies]
-ink_e2e = { git = "https://github.com/use-ink/ink", branch = "master" }
+ink_e2e = { git = "https://github.com/use-ink/ink", branch = "alex/update-dependencies" }
 
 [lib]
 path = "lib.rs"

--- a/crates/cargo-contract/Cargo.toml
+++ b/crates/cargo-contract/Cargo.toml
@@ -40,8 +40,8 @@ jsonschema = "0.29"
 schemars = "0.8"
 comfy-table = "7.1.1"
 
-ink_metadata = { git = "https://github.com/use-ink/ink", branch = "alex/update-dependencies", default-features = false, features = ["std", "derive"] }
-ink_env = { git = "https://github.com/use-ink/ink", branch = "alex/update-dependencies" }
+ink_metadata = { git = "https://github.com/use-ink/ink", branch = "master", default-features = false, features = ["std", "derive"] }
+ink_env = { git = "https://github.com/use-ink/ink", branch = "master" }
 
 # dependencies for extrinsics (deploying and calling a contract)
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/crates/cargo-contract/Cargo.toml
+++ b/crates/cargo-contract/Cargo.toml
@@ -40,23 +40,23 @@ jsonschema = "0.29"
 schemars = "0.8"
 comfy-table = "7.1.1"
 
-ink_metadata = { git = "https://github.com/use-ink/ink", branch = "master", default-features = false, features = ["std", "derive"] }
-ink_env = { git = "https://github.com/use-ink/ink", branch = "master" }
+ink_metadata = { git = "https://github.com/use-ink/ink", branch = "alex/update-dependencies", default-features = false, features = ["std", "derive"] }
+ink_env = { git = "https://github.com/use-ink/ink", branch = "alex/update-dependencies" }
 
 # dependencies for extrinsics (deploying and calling a contract)
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 subxt = { version = "0.38.1", features = ["substrate-compat"] }
 hex = "0.4.3"
 
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", rev = "f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a", default-features = false}
-sp-weights = { git = "https://github.com/paritytech/polkadot-sdk", rev = "f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a" }
+sp-core = { version = "36.1.0", default-features = false}
+sp-weights = "31.1.0"
 
 # todo Pin until https://github.com/jhpratt/deranged/issues/18 is resolved
 deranged = { version = "=0.4.0", default-features = false }
 
 [build-dependencies]
 anyhow = "1.0.95"
-substrate-build-script-utils = { git = "https://github.com/paritytech/polkadot-sdk", rev = "f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a" }
+substrate-build-script-utils = "11.0.0"
 current_platform = "0.2.0"
 which = "7.0.1"
 

--- a/crates/cargo-contract/Cargo.toml
+++ b/crates/cargo-contract/Cargo.toml
@@ -48,7 +48,7 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 subxt = { version = "0.38.1", features = ["substrate-compat"] }
 hex = "0.4.3"
 
-sp-core = { version = "36.1.0", default-features = false}
+sp-core = { version = "36.1.0", default-features = false }
 sp-weights = "31.1.0"
 
 # todo Pin until https://github.com/jhpratt/deranged/issues/18 is resolved

--- a/crates/extrinsics/Cargo.toml
+++ b/crates/extrinsics/Cargo.toml
@@ -42,11 +42,11 @@ sp-weights = { version = "31.1.0", default-features = false }
 pallet-revive = "0.5.0"
 pallet-revive-uapi = { version = "0.4.0", default-features = false, features = ["unstable-hostfn", "scale"] }
 
-ink_metadata = { git = "https://github.com/use-ink/ink", branch = "alex/update-dependencies", default-features = false, features = ["std", "derive"] }
-ink_env = { git = "https://github.com/use-ink/ink", branch = "alex/update-dependencies" }
+ink_metadata = { git = "https://github.com/use-ink/ink", branch = "master", default-features = false, features = ["std", "derive"] }
+ink_env = { git = "https://github.com/use-ink/ink", branch = "master" }
 
 [dev-dependencies]
-ink = { git = "https://github.com/use-ink/ink", branch = "alex/update-dependencies" }
+ink = { git = "https://github.com/use-ink/ink", branch = "master" }
 assert_cmd = "2.0.16"
 regex = "1.11.1"
 predicates = "3.1.3"

--- a/crates/extrinsics/Cargo.toml
+++ b/crates/extrinsics/Cargo.toml
@@ -36,17 +36,17 @@ subxt = "0.38.1"
 hex = "0.4.3"
 derivative = "2.2.0"
 
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", rev = "f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a", default-features = false }
-sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", rev = "f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a" }
-sp-weights = { git = "https://github.com/paritytech/polkadot-sdk", rev = "f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a", default-features = false }
-pallet-revive = { git = "https://github.com/paritytech/polkadot-sdk", rev = "f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a"}
-pallet-revive-uapi = { git = "https://github.com/paritytech/polkadot-sdk", rev = "f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a", default-features = false, features = ["unstable-hostfn", "scale"] }
+sp-core = { version = "36.1.0", default-features = false }
+sp-runtime = "41.1.0"
+sp-weights = { version = "31.1.0", default-features = false }
+pallet-revive = "0.5.0"
+pallet-revive-uapi = { version = "0.4.0", default-features = false, features = ["unstable-hostfn", "scale"] }
 
-ink_metadata = { git = "https://github.com/use-ink/ink", branch = "master", default-features = false, features = ["std", "derive"] }
-ink_env = { git = "https://github.com/use-ink/ink", branch = "master" }
+ink_metadata = { git = "https://github.com/use-ink/ink", branch = "alex/update-dependencies", default-features = false, features = ["std", "derive"] }
+ink_env = { git = "https://github.com/use-ink/ink", branch = "alex/update-dependencies" }
 
 [dev-dependencies]
-ink = { git = "https://github.com/use-ink/ink", branch = "master" }
+ink = { git = "https://github.com/use-ink/ink", branch = "alex/update-dependencies" }
 assert_cmd = "2.0.16"
 regex = "1.11.1"
 predicates = "3.1.3"

--- a/crates/transcode/Cargo.toml
+++ b/crates/transcode/Cargo.toml
@@ -24,8 +24,8 @@ contract-metadata = { version = "6.0.0-alpha", path = "../metadata" }
 escape8259 = "0.5.2"
 hex = "0.4.3"
 indexmap = "2.7.1"
-ink_env = { git = "https://github.com/use-ink/ink", branch = "alex/update-dependencies" }
-ink_metadata = { git = "https://github.com/use-ink/ink", branch = "alex/update-dependencies", default-features = false, features = ["std", "derive"] }
+ink_env = { git = "https://github.com/use-ink/ink", branch = "master" }
+ink_metadata = { git = "https://github.com/use-ink/ink", branch = "master", default-features = false, features = ["std", "derive"] }
 itertools = "0.14.0"
 tracing = "0.1.40"
 nom = "7.1.3"
@@ -41,7 +41,7 @@ regex = "1.11.1"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-ink = { git = "https://github.com/use-ink/ink", branch = "alex/update-dependencies", features = ["unstable-hostfn"] }
+ink = { git = "https://github.com/use-ink/ink", branch = "master", features = ["unstable-hostfn"] }
 sp-core = { version = "36.1.0", default-features = false }
 sp-keyring = { version = "41.0.0", default-features = false }
 

--- a/crates/transcode/Cargo.toml
+++ b/crates/transcode/Cargo.toml
@@ -24,8 +24,8 @@ contract-metadata = { version = "6.0.0-alpha", path = "../metadata" }
 escape8259 = "0.5.2"
 hex = "0.4.3"
 indexmap = "2.7.1"
-ink_env = { git = "https://github.com/use-ink/ink", branch = "master" }
-ink_metadata = { git = "https://github.com/use-ink/ink", branch = "master", default-features = false, features = ["std", "derive"] }
+ink_env = { git = "https://github.com/use-ink/ink", branch = "alex/update-dependencies" }
+ink_metadata = { git = "https://github.com/use-ink/ink", branch = "alex/update-dependencies", default-features = false, features = ["std", "derive"] }
 itertools = "0.14.0"
 tracing = "0.1.40"
 nom = "7.1.3"
@@ -41,9 +41,9 @@ regex = "1.11.1"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-ink = { git = "https://github.com/use-ink/ink", branch = "master", features = ["unstable-hostfn"] }
-sp-core = { git = "https://github.com/paritytech/polkadot-sdk", rev = "f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a", default-features = false }
-sp-keyring = { git = "https://github.com/paritytech/polkadot-sdk", rev = "f8c90b2a01ec77579bccd21ae17bd6ff2eeffd6a", default-features = false }
+ink = { git = "https://github.com/use-ink/ink", branch = "alex/update-dependencies", features = ["unstable-hostfn"] }
+sp-core = { version = "36.1.0", default-features = false }
+sp-keyring = { version = "41.0.0", default-features = false }
 
 [features]
 # This `std` feature is required for testing using an inline contract's metadata, because `ink!` annotates the metadata


### PR DESCRIPTION
Update dependencies to 2503 qne import the latests versions released in crates.io.
- polkavm-linker to "0.22.0"

https://github.com/use-ink/ink-alliance/issues/50

Note: Once this PR https://github.com/use-ink/ink/pull/2478 is merged and the `ink_metadata`, `ink`, `ink_e2e`, and `ink_env` crates are published, this PR should be updated to reference the newly released versions. After that, it will be ready to merge.