### PR TITLE
refactor: contract_address to have account id in parameters

### DIFF
--- a/crates/extrinsics/src/instantiate.rs
+++ b/crates/extrinsics/src/instantiate.rs
@@ -352,10 +352,11 @@ where
         storage_deposit_limit: E::Balance,
     ) -> Result<InstantiateExecResult<C>, ErrorVariant> {
         let code_hash = None; // todo
+        let account_id = Signer::account_id(self.opts.signer());
         let contract_address = contract_address(
             &self.client,
             &self.rpc,
-            self.opts.signer(),
+            account_id,
             &self.args.salt,
             &code[..],
             &self.args.data[..],
@@ -402,10 +403,11 @@ where
             submit_extrinsic(&self.client, &self.rpc, &call, self.opts.signer()).await?;
 
         let code = fetch_contract_binary(&self.client, &self.rpc, &code_hash).await?;
+        let account_id = Signer::account_id(self.opts.signer());
         let contract_address = contract_address(
             &self.client,
             &self.rpc,
-            self.opts.signer(),
+            account_id,
             &self.args.salt,
             &code[..],
             &self.args.data[..],
@@ -631,15 +633,14 @@ pub enum Code {
 }
 
 /// Derives a contract address.
-pub async fn contract_address<C: Config, Signer: tx::Signer<C> + Clone>(
+pub async fn contract_address<C: Config>(
     client: &OnlineClient<C>,
     rpc: &LegacyRpcMethods<C>,
-    signer: &Signer,
+    account_id: C::AccountId,
     salt: &Option<[u8; 32]>,
     code: &[u8],
     data: &[u8],
 ) -> Result<H160, subxt::Error> {
-    let account_id = Signer::account_id(signer);
     let deployer = AccountIdMapper::to_address(&account_id.encode()[..]);
 
     // copied from `pallet-revive`


### PR DESCRIPTION
Refactored `contract_address` to take an `AccountId` instead of a `Signer`. This makes the function easier to reuse, especially in cases where we only have the user's address and not a full signer, is useful for example in `pop-cli` where we sign the deployment of the contract using a wallet UI.
