### PR TITLE
fix: verifiable image build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -177,6 +177,10 @@ Please see [#1930](https://github.com/use-ink/cargo-contract/pull/1930) for more
 - Deny overflowing (and lossy) integer type cast operations - [#1895](https://github.com/use-ink/cargo-contract/pull/1895)
 - Remove linting by default, `--skip-linting` and `--lint` flag in `cargo contract build` and add a new command `lint` - [#2013](https://github.com/use-ink/cargo-contract/pull/2013)
 
+### Fixed
+
+- Resolved verifiable-build image failures within `release-verifiable-image` workflow - [#2018](https://github.com/use-ink/cargo-contract/pull/2018)
+
 ## [5.0.1]
 
 ### Changed

--- a/build-image/Dockerfile
+++ b/build-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/bitnami/minideb:bullseye-amd64 as slimmed-rust
+FROM debian:stable-slim AS slimmed-rust
 
 # The rust version to use
 ARG RUST_VERSION=stable
@@ -13,20 +13,21 @@ ARG CARGO_CONTRACT_REV
 # Tag to use in git repository
 ARG CARGO_CONTRACT_TAG
 # gcc package version
-ARG GCC_VERSION=4:10.2.1-1
+ARG GCC_VERSION=4:12.2.0-3
 # wget package version
-ARG WGET_VERSION=1.21-1+deb11u1
+ARG WGET_VERSION=1.21.3-1+deb12u1
 # g++ package version
-ARG G_VERSION=4:10.2.1-1
-ARG MUSL_V=1.2.2-1
+ARG G_VERSION=4:12.2.0-3
+ARG MUSL_V=1.2.3-1
 # The Rust version used by `ink_linting`.
 # See https://github.com/use-ink/ink/blob/master/linting/rust-toolchain.toml.
 ARG RUST_LINTER_VERSION=nightly-2025-02-20
+ARG TARGETARCH
 
 # Metadata
 LABEL ink.use.image.vendor="Use Ink" \
     ink.use.image.title="useink/contracts-verifiable" \
-    ink.use.image.description="Inherits from docker.io/bitnami/minideb:bullseye. \
+    ink.use.image.description="Inherits from debian:stable-slim. \
     rust nightly, clippy, rustfmt, miri, rust-src, rustc-dev, grcov, rust-covfix, \
     llvm-tools-preview, cargo-contract, xargo, binaryen, parallel, codecov, ink, solang" \
     ink.use.image.documentation="https://github.com/use-ink/cargo-contract/blob/master/\
@@ -45,15 +46,23 @@ LABEL ink.use.image.vendor="Use Ink" \
 
 ENV RUSTUP_HOME=/usr/local/rustup \
     CARGO_HOME=/usr/local/cargo \
-    PATH=/usr/local/cargo/bin:$PATH
+    PATH=/usr/local/cargo/bin:$PATH \
+    ARCH=$TARGETARCH
 
 # Minimal Rust dependencies.
 RUN set -eux \
-    && apt-get update && apt-get -y install wget=${WGET_VERSION} \
-    && url="https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init" \
+    && apt-get update && apt-get -y install wget=${WGET_VERSION} gcc=${GCC_VERSION} \
+    # Map target architecture to Rust format
+    # NOTE: `arm64` support is for debugging this `Dockerfile` locally only! No `arm64` images are to be published.
+    && case ${TARGETARCH} in \
+            "amd64")  RUST_ARCH="x86_64"  ;; \
+            "arm64")  RUST_ARCH="aarch64" ;; \
+            *)        RUST_ARCH=${TARGETARCH} ;; \
+    esac \
+    && url="https://static.rust-lang.org/rustup/dist/${RUST_ARCH}-unknown-linux-gnu/rustup-init" \
     && wget "$url" \
     && chmod +x rustup-init \
-    && ./rustup-init -y --no-modify-path --profile minimal --component rust-src,rustfmt,clippy --default-toolchain $RUST_VERSION  \
+    && ./rustup-init -y --no-modify-path --profile minimal --component rust-src,rustfmt,clippy --default-toolchain $RUST_VERSION \
     && rm rustup-init \
     # Install nightly toolchain required by `cargo contract lint --extra-lints` command
     && rustup install ${RUST_LINTER_VERSION} --profile minimal \
@@ -62,11 +71,15 @@ RUN set -eux \
     && rustup --version \
     && cargo --version \
     && rustc --version \
+    # Clean up layer
     && apt-get remove -y --auto-remove wget \
-    && apt-get -y install gcc=${GCC_VERSION} \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get clean \
+    && apt-get autoclean \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/cache/apt/archives/* \
+        /usr/share/doc/* /usr/share/man/* /usr/share/locale/* /var/log/* /var/cache/debconf/*
 
-FROM slimmed-rust as cc-builder
+FROM slimmed-rust AS cc-builder
 ARG CARGO_CONTRACT_VERSION
 ARG GCC_VERSION
 ARG G_VERSION
@@ -105,18 +118,10 @@ RUN apt-get -y update && apt-get -y install gcc=${GCC_VERSION} g++=${G_VERSION} 
     # Check if build and lint works
     && mkdir -p $DYLINT_DRIVER_PATH \
     && cargo contract new test \
-    # Generate /usr/local/dylint_drivers/nightly-2024-02-20-x86_64-unknown-linux-gnu/dylint-driver bin
-    && cd test && cargo contract build --verbose --release && cargo contract lint --extra-lints && cd .. \
-    && rm -rf test \
-    # apt clean up
-    && apt-get remove -y gnupg libssl-dev pkg-config \
-    && apt-get autoremove -y \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    # Cleanup cargo
-    && rm -rf ${CARGO_HOME}/"registry" ${CARGO_HOME}/"git"
+    # Generate /usr/local/dylint_drivers/${RUST_LINTER_VERSION}-{ARCH}-unknown-linux-gnu/dylint-driver binary
+    && cd test && cargo contract build --verbose --release && cargo contract lint --extra-lints && cd ..
 
-FROM slimmed-rust as ink-dev
+FROM slimmed-rust AS ink-dev
 
 COPY --from=cc-builder /usr/local/dylint_drivers /usr/local/dylint_drivers
 COPY --from=cc-builder /usr/local/cargo/bin/cargo-contract /usr/local/bin/cargo-contract

--- a/build-image/README.md
+++ b/build-image/README.md
@@ -2,7 +2,7 @@
 
 todo reread this whole file
 
-Docker image based on the minimalistic Debian image `bitnami/minideb:bullseye-amd64`.
+Docker image based on the minimalistic Debian image `debian:stable-slim`.
 
 Used for reproducible builds in `cargo contract build --verifiable`
 
@@ -28,6 +28,7 @@ docker run -d \
 ```
 
 For multi-contract projects, like in the example below:
+
 ```
 my-app/
 ├─ ink-project-a/
@@ -38,10 +39,10 @@ my-app/
 │  ├─ lib.rs
 ├─ rust-toolchain
 ```
+
 Make sure to run the command inside `my-app` directory and specify a relative manifest path
 to the root contract:
 `cargo contract build --verifiable --release --manifest-path ink-project-a/Cargo.toml`
-
 
 **Apple Silicon performance**
 
@@ -54,7 +55,7 @@ _Settings_ -> _Features in development_ tab in Docker Desktop App.
 Build docker image:
 
 ```bash
-docker buildx build -t useink/contracts-verifiable:0.0.1-local --build-arg CARGO_CONTRACT_VERSION=4.1.0 .
+docker buildx build -t useink/contracts-verifiable:0.0.1-local --build-arg CARGO_CONTRACT_VERSION=6.0.0-alpha .
 ```
 
 Run docker container:

--- a/crates/build/src/lint.rs
+++ b/crates/build/src/lint.rs
@@ -36,7 +36,7 @@ pub const TOOLCHAIN_VERSION: &str = "nightly-2025-02-20";
 /// Git repository with ink_linting libraries
 pub const GIT_URL: &str = "https://github.com/use-ink/ink";
 /// Git revision number of the linting crate
-pub const GIT_REV: &str = "87a97b244f7eb30fe04b9dba59294af9f91646d4";
+pub const GIT_REV: &str = "5dc1624c3fa279cc57b4418b939cc089790f42f0";
 
 /// Run linting that involves two steps: `clippy` and `dylint`. Both are mandatory as
 /// they're part of the compilation process and implement security-critical features.


### PR DESCRIPTION
Dated manifest at specified revision causes compilation issues.

## Summary

- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependent on the specific version of `ink` or `pallet-contracts`? Not specifically, but it does update the revision of the linting crate to`5dc1624c3fa279cc57b4418b939cc089790f42f0` to resolve the build issues experienced.
<!--- Provide a general summary of your changes -->

Resolves the [CI build issues](https://github.com/use-ink/cargo-contract/actions/workflows/release-image.yml) of the `release-verifiable-image` workflow, which were due to the linting function pointing to an ink commit with a broken manifest.

## Description
Updates the commit of the linting crate to `5dc1624c3fa279cc57b4418b939cc089790f42f0`, which is after standardising on `stable2503` of the Polkadot SDK. 

Updates the base image to `debian:stable-slim` which is marginally smaller but more importantly, aligns with the base image used at https://github.com/use-ink/docker-images. No updates have been made to this since it was created 2 years ago, so seemed opportune refreshing due to the breaking changes of v6.

Built locally successfully:
![image](https://github.com/user-attachments/assets/a04af59d-6525-4ec6-8299-bfc67219fbca)

Note that I had to manually add the required tag via `docker image tag useink/contracts-verifiable:local useink/contracts-verifiable:6.0.0-alpha`, implying that a release will need to be manually triggered once this PR is merged.

![image](https://github.com/user-attachments/assets/8c57f869-0fd3-4229-950a-c899df54a408)
![image](https://github.com/user-attachments/assets/40d4b122-3c8b-45b5-9ca1-3ac9955871d2)



## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have added an entry to `CHANGELOG.md`
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
