### PR TITLE
chore: update ink dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,7 +77,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "once_cell",
  "version_check",
 ]
@@ -89,7 +89,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "once_cell",
  "serde",
  "version_check",
@@ -155,12 +155,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5189fa9a8797e92396bc4b4454c5f2073a4945f7c2b366af9af60f9536558f7a"
+checksum = "0068ae277f5ee3153a95eaea8ff10e188ed8ccde9b7f9926305415a2c0ab2442"
 dependencies = [
- "alloy-primitives 1.0.0",
- "alloy-sol-type-parser 1.0.0",
+ "alloy-primitives 1.1.0",
+ "alloy-sol-type-parser 1.1.0",
  "serde",
  "serde_json",
 ]
@@ -175,7 +175,7 @@ dependencies = [
  "bytes",
  "cfg-if",
  "const-hex",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "hex-literal 0.4.1",
  "itoa",
  "proptest",
@@ -197,8 +197,8 @@ dependencies = [
  "const-hex",
  "derive_more 2.0.1",
  "foldhash",
- "hashbrown 0.15.2",
- "indexmap 2.8.0",
+ "hashbrown 0.15.3",
+ "indexmap 2.9.0",
  "itoa",
  "k256",
  "keccak-asm",
@@ -214,9 +214,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70b98b99c1dcfbe74d7f0b31433ff215e7d1555e367d90e62db904f3c9d4ff53"
+checksum = "6a12fe11d0b8118e551c29e1a67ccb6d01cc07ef08086df30f07487146de6fa1"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -224,14 +224,14 @@ dependencies = [
  "const-hex",
  "derive_more 2.0.1",
  "foldhash",
- "hashbrown 0.15.2",
- "indexmap 2.8.0",
+ "hashbrown 0.15.3",
+ "indexmap 2.9.0",
  "itoa",
  "k256",
  "keccak-asm",
  "paste",
  "proptest",
- "rand 0.9.0",
+ "rand 0.9.1",
  "ruint",
  "rustc-hash 2.1.1",
  "serde",
@@ -261,7 +261,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "syn-solidity 0.4.2",
  "tiny-keccak",
 ]
@@ -277,21 +277,21 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "alloy-sol-macro"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60fcfa26956bcb22f66ab13407115197f26ef23abca5b48d39a1946897382d74"
+checksum = "5d3ef8e0d622453d969ba3cded54cf6800efdc85cb929fe22c5bdf8335666757"
 dependencies = [
- "alloy-sol-macro-expander 1.0.0",
- "alloy-sol-macro-input 1.0.0",
+ "alloy-sol-macro-expander 1.1.0",
+ "alloy-sol-macro-input 1.1.0",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -303,30 +303,30 @@ dependencies = [
  "alloy-sol-macro-input 0.8.25",
  "const-hex",
  "heck 0.5.0",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "syn-solidity 0.8.25",
  "tiny-keccak",
 ]
 
 [[package]]
 name = "alloy-sol-macro-expander"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a9b402f0013f1ff8c24066eeafc2207a8e52810a2b18b77776ce7fead5af41"
+checksum = "f0e84bd0693c69a8fbe3ec0008465e029c6293494df7cb07580bf4a33eff52e1"
 dependencies = [
- "alloy-sol-macro-input 1.0.0",
+ "alloy-sol-macro-input 1.1.0",
  "const-hex",
  "heck 0.5.0",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
- "syn-solidity 1.0.0",
+ "syn 2.0.101",
+ "syn-solidity 1.1.0",
  "tiny-keccak",
 ]
 
@@ -342,15 +342,15 @@ dependencies = [
  "macro-string",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "syn-solidity 0.8.25",
 ]
 
 [[package]]
 name = "alloy-sol-macro-input"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d02d61741337bb6b3f4899c2e3173fe17ffa2810e143d3b28acd953197c8dd79"
+checksum = "f3de663412dadf9b64f4f92f507f78deebcc92339d12cf15f88ded65d41c7935"
 dependencies = [
  "const-hex",
  "dunce",
@@ -358,8 +358,8 @@ dependencies = [
  "macro-string",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
- "syn-solidity 1.0.0",
+ "syn 2.0.101",
+ "syn-solidity 1.1.0",
 ]
 
 [[package]]
@@ -374,9 +374,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b5f5f9f561c29f78ea521ebe2e5ac1633f1b1442dae582f68ecd57c6350042"
+checksum = "251273c5aa1abb590852f795c938730fa641832fc8fa77b5478ed1bf11b6097e"
 dependencies = [
  "serde",
  "winnow",
@@ -409,13 +409,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-types"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02635bce18205ff8149fb752c753b0a91ea3f3c8ee04c58846448be4811a640"
+checksum = "5460a975434ae594fe2b91586253c1beb404353b78f0a55bf124abcd79557b15"
 dependencies = [
- "alloy-json-abi 1.0.0",
- "alloy-primitives 1.0.0",
- "alloy-sol-macro 1.0.0",
+ "alloy-json-abi 1.1.0",
+ "alloy-primitives 1.1.0",
+ "alloy-sol-macro 1.1.0",
  "const-hex",
  "serde",
 ]
@@ -487,9 +487,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.97"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcfed56ad506cb2c684a14971b8861fdc3baaaae314b9e5f9bb532cbe3ba7a4f"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "approx"
@@ -511,7 +511,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -640,7 +640,7 @@ dependencies = [
  "ark-std 0.5.0",
  "educe",
  "fnv",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
  "itertools 0.13.0",
  "num-bigint",
  "num-integer",
@@ -795,7 +795,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62945a2f7e6de02a31fe400aa489f0e0f5b2502e69f95f853adb82a96c7a6b60"
 dependencies = [
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -833,7 +833,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -874,7 +874,7 @@ dependencies = [
  "ark-std 0.5.0",
  "educe",
  "fnv",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
 ]
 
 [[package]]
@@ -945,7 +945,7 @@ checksum = "213888f660fddcca0d257e88e54ac05bca01885f258ccdf695bafd77031bb69d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1007,7 +1007,7 @@ dependencies = [
  "ark-std 0.5.0",
  "digest 0.10.7",
  "rand_chacha 0.3.1",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "w3f-ring-proof",
  "zeroize",
 ]
@@ -1088,12 +1088,12 @@ dependencies = [
  "parachains-common",
  "parachains-runtimes-test-utils",
  "parity-scale-codec",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
  "staging-parachain-info",
- "staging-xcm 14.2.1",
- "staging-xcm-builder 17.0.4",
- "staging-xcm-executor 17.0.1",
+ "staging-xcm 14.2.2",
+ "staging-xcm-builder 17.0.5",
+ "staging-xcm-executor 17.0.2",
  "substrate-wasm-builder",
 ]
 
@@ -1115,9 +1115,9 @@ dependencies = [
  "scale-info",
  "sp-api 34.0.0",
  "sp-runtime 39.0.5",
- "staging-xcm 14.2.1",
- "staging-xcm-builder 17.0.4",
- "staging-xcm-executor 17.0.1",
+ "staging-xcm 14.2.2",
+ "staging-xcm-builder 17.0.5",
+ "staging-xcm-executor 17.0.2",
  "substrate-wasm-builder",
 ]
 
@@ -1135,14 +1135,15 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30ca9a001c1e8ba5149f91a74362376cc6bc5b919d92d988668657bd570bdcec"
+checksum = "bb812ffb58524bdd10860d7d974e2f01cc0950c2438a74ee5ec2e2280c6c4ffa"
 dependencies = [
  "async-task",
  "concurrent-queue",
  "fastrand",
  "futures-lite",
+ "pin-project-lite",
  "slab",
 ]
 
@@ -1249,7 +1250,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1266,13 +1267,13 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "auto_impl"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12882f59de5360c748c4cbf569a042d5fb0eb515f7bea9c1f470b47f6ffbd73"
+checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1368,7 +1369,7 @@ dependencies = [
  "rand_core 0.6.4",
  "ripemd",
  "secp256k1 0.27.0",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -1488,9 +1489,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.7.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b17679a8d69b6d7fd9cd9801a536cec9fa5e5970b69f9d4747f70b39b031f5e7"
+checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
 dependencies = [
  "arrayref",
  "arrayvec 0.7.6",
@@ -1600,7 +1601,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1646,7 +1647,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-std",
 ]
 
@@ -1736,7 +1737,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "sp-std",
@@ -1778,9 +1779,9 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-std",
- "staging-xcm 14.2.1",
+ "staging-xcm 14.2.2",
 ]
 
 [[package]]
@@ -1793,7 +1794,7 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-runtime 39.0.5",
- "staging-xcm 14.2.1",
+ "staging-xcm 14.2.2",
 ]
 
 [[package]]
@@ -1811,7 +1812,7 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-runtime 39.0.5",
  "sp-std",
- "staging-xcm 14.2.1",
+ "staging-xcm 14.2.2",
 ]
 
 [[package]]
@@ -1849,13 +1850,13 @@ dependencies = [
  "parachains-runtimes-test-utils",
  "parity-scale-codec",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-keyring 39.0.0",
  "sp-runtime 39.0.5",
  "sp-tracing",
- "staging-xcm 14.2.1",
- "staging-xcm-builder 17.0.4",
- "staging-xcm-executor 17.0.1",
+ "staging-xcm 14.2.2",
+ "staging-xcm-builder 17.0.5",
+ "staging-xcm-executor 17.0.2",
 ]
 
 [[package]]
@@ -1881,11 +1882,11 @@ dependencies = [
  "pallet-utility",
  "parity-scale-codec",
  "scale-info",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
  "sp-std",
  "sp-trie 37.0.0",
- "staging-xcm 14.2.1",
+ "staging-xcm 14.2.2",
  "tuplex",
 ]
 
@@ -1904,15 +1905,15 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "tinyvec",
 ]
 
 [[package]]
 name = "bstr"
-version = "1.11.3"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
 dependencies = [
  "memchr",
  "regex-automata 0.4.9",
@@ -1970,9 +1971,9 @@ checksum = "5ce89b21cab1437276d2650d57e971f9d548a2d9037cc231abdc0562b97498ce"
 
 [[package]]
 name = "bytemuck"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
+checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
 
 [[package]]
 name = "byteorder"
@@ -2076,9 +2077,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.17"
+version = "1.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fcb57c740ae1daf453ae85f16e37396f672b039e00d9d866e07ddb24e328e3a"
+checksum = "8691782945451c1c383942c4874dbe63814f61cb57ef773cda2972682b7bb3c0"
 dependencies = [
  "jobserver",
  "libc",
@@ -2125,9 +2126,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.40"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -2149,9 +2150,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.34"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e958897981290da2a852763fe9cdb89cd36977a5d729023127095fa94d95e2ff"
+checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -2159,9 +2160,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.34"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83b0f35019843db2160b5bb19ae09b4e6411ac33fc6a712003c33e03090e2489"
+checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
 dependencies = [
  "anstream",
  "anstyle",
@@ -2178,7 +2179,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2306,7 +2307,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "once_cell",
  "tiny-keccak",
 ]
@@ -2365,12 +2366,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
-name = "constcat"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd7e35aee659887cbfb97aaf227ac12cad1a9d7c71e55ff3376839ed4e282d08"
-
-[[package]]
 name = "contract-analyze"
 version = "6.0.0-alpha"
 dependencies = [
@@ -2411,7 +2406,7 @@ dependencies = [
  "term_size",
  "tokio",
  "tokio-stream",
- "toml 0.8.20",
+ "toml 0.8.22",
  "tracing",
  "url",
  "uzers",
@@ -2484,7 +2479,7 @@ dependencies = [
  "contract-metadata",
  "escape8259",
  "hex",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "ink",
  "ink_env",
  "ink_metadata",
@@ -2804,16 +2799,16 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
- "staging-xcm 14.2.1",
+ "staging-xcm 14.2.2",
 ]
 
 [[package]]
 name = "cumulus-pallet-parachain-system"
-version = "0.17.1"
+version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "546403ee1185f4051a74cc9c9d76e82c63cac3fb68e1bf29f61efb5604c96488"
+checksum = "ab4255169e8fb9da8ef21630a381067483b2ffb9a3af23357ea150ee7fbdd517"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -2835,14 +2830,14 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-externalities 0.29.0",
  "sp-inherents 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
  "sp-std",
  "sp-trie 37.0.0",
  "sp-version 37.0.0",
- "staging-xcm 14.2.1",
- "staging-xcm-builder 17.0.4",
+ "staging-xcm 14.2.2",
+ "staging-xcm-builder 17.0.5",
  "trie-db 0.29.1",
 ]
 
@@ -2855,7 +2850,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2899,16 +2894,16 @@ dependencies = [
  "frame-system 38.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
- "staging-xcm 14.2.1",
+ "staging-xcm 14.2.2",
 ]
 
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
-version = "0.17.2"
+version = "0.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "105767016b8136031f14cca439edf28c8493e3556e6781847758511bfef2477a"
+checksum = "a4f4b7dec3206640120013d2ce6b476cbac8be9b93335f66b40255711db81301"
 dependencies = [
  "bounded-collections",
  "bp-xcm-bridge-hub-router",
@@ -2923,11 +2918,11 @@ dependencies = [
  "polkadot-runtime-parachains",
  "scale-info",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
- "staging-xcm 14.2.1",
- "staging-xcm-builder 17.0.4",
- "staging-xcm-executor 17.0.1",
+ "staging-xcm 14.2.2",
+ "staging-xcm-builder 17.0.5",
+ "staging-xcm-executor 17.0.2",
 ]
 
 [[package]]
@@ -2943,7 +2938,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-runtime 39.0.5",
- "staging-xcm 14.2.1",
+ "staging-xcm 14.2.2",
 ]
 
 [[package]]
@@ -2974,7 +2969,7 @@ dependencies = [
  "sp-api 34.0.0",
  "sp-runtime 39.0.5",
  "sp-trie 37.0.0",
- "staging-xcm 14.2.1",
+ "staging-xcm 14.2.2",
 ]
 
 [[package]]
@@ -3033,9 +3028,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-primitives-utility"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bdcf4d46dd93f1e6d5dd6d379133566a44042ba6476d04bdcbdb4981c622ae4"
+checksum = "4f8ac1b7ed4431370526ed12df9435d73fa2fcb2a5b5c2df8a16f243865f1f40"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support 38.2.0",
@@ -3044,9 +3039,9 @@ dependencies = [
  "parity-scale-codec",
  "polkadot-runtime-common",
  "sp-runtime 39.0.5",
- "staging-xcm 14.2.1",
- "staging-xcm-builder 17.0.4",
- "staging-xcm-executor 17.0.1",
+ "staging-xcm 14.2.2",
+ "staging-xcm-builder 17.0.5",
+ "staging-xcm-executor 17.0.2",
 ]
 
 [[package]]
@@ -3093,14 +3088,14 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "cxx"
-version = "1.0.151"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb3e596b379180315d2f934231e233a2fc745041f88231807774093d8de45f2"
+checksum = "a71ea7f29c73f7ffa64c50b83c9fe4d3a6d4be89a86b009eb80d5a6d3429d741"
 dependencies = [
  "cc",
  "cxxbridge-cmd",
@@ -3112,54 +3107,54 @@ dependencies = [
 
 [[package]]
 name = "cxx-build"
-version = "1.0.151"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3743fae7f47620cd34ec23bab819db9ee52da93166a058f87ab0ad99d777dc9b"
+checksum = "36a8232661d66dcf713394726157d3cfe0a89bfc85f52d6e9f9bbc2306797fe7"
 dependencies = [
  "cc",
  "codespan-reporting",
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "cxxbridge-cmd"
-version = "1.0.151"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaea0273c049b126a3918df88a1670c9c0168e0738df9370a988ff69070d4fff"
+checksum = "4f44296c8693e9ea226a48f6a122727f77aa9e9e338380cb021accaeeb7ee279"
 dependencies = [
  "clap",
  "codespan-reporting",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "cxxbridge-flags"
-version = "1.0.151"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020a9a3d6b792aab7f30f6e323893ad7f45052e572cde5d014c47fe67c89495f"
+checksum = "c42f69c181c176981ae44ba9876e2ea41ce8e574c296b38d06925ce9214fb8e4"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.151"
+version = "1.0.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee54cd01f94db0328c4c73036d38bd8c3bb88927e953d05ffefe743edbf4eb68"
+checksum = "8faff5d4467e0709448187df29ccbf3b0982cc426ee444a193f87b11afb565a8"
 dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "darling"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -3167,34 +3162,34 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "der"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
  "zeroize",
@@ -3229,18 +3224,18 @@ checksum = "d65d7ce8132b7c0e54497a4d9a55a1c2a0912a0d786cf894472ba818fba45762"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "derive-where"
-version = "1.2.7"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62d671cc41a825ebabc75757b62d3d168c577f9149b2d49ece1dad1f72119d25"
+checksum = "e73f2692d4bd3cac41dca28934a39894200c9fabf49586d77d0e5954af1d7902"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3251,20 +3246,20 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "derive_more"
-version = "0.99.19"
+version = "0.99.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da29a38df43d6f156149c9b43ded5e018ddff2a855cf2cfd62e8cd7d079c69f"
+checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3293,7 +3288,7 @@ checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "unicode-xid",
 ]
 
@@ -3305,7 +3300,7 @@ checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "unicode-xid",
 ]
 
@@ -3392,7 +3387,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3422,9 +3417,9 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.100",
+ "syn 2.0.101",
  "termcolor",
- "toml 0.8.20",
+ "toml 0.8.22",
  "walkdir",
 ]
 
@@ -3470,7 +3465,7 @@ checksum = "7e8671d54058979a37a26f3511fbf8d198ba1aa35ffb202c42587d918d77213a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3513,7 +3508,7 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -3529,7 +3524,7 @@ dependencies = [
  "hashbrown 0.14.5",
  "hex",
  "rand_core 0.6.4",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "zeroize",
 ]
 
@@ -3542,7 +3537,7 @@ dependencies = [
  "enum-ordinalize",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3603,7 +3598,7 @@ checksum = "0d28318a75d4aead5c4db25382e8ef717932d0346600cacae6357eb5941bc5ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3623,7 +3618,7 @@ checksum = "fc4caf64a58d7a6d65ab00639b046ff54399a39f5f2554728895ace4b297cd79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3634,7 +3629,7 @@ checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3670,9 +3665,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -3799,7 +3794,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -3998,7 +3993,7 @@ dependencies = [
  "sp-api 34.0.0",
  "sp-application-crypto 38.0.0",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
  "sp-runtime-interface 28.0.0",
  "sp-storage 21.0.0",
@@ -4023,7 +4018,7 @@ dependencies = [
  "sp-api 36.0.1",
  "sp-application-crypto 40.1.0",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-runtime-interface 29.0.1",
  "sp-storage 22.0.0",
@@ -4041,7 +4036,7 @@ dependencies = [
  "frame-system 38.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
 ]
 
@@ -4068,7 +4063,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4102,7 +4097,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
  "sp-tracing",
 ]
@@ -4189,7 +4184,7 @@ dependencies = [
  "sp-debug-derive",
  "sp-genesis-builder 0.15.1",
  "sp-inherents 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-metadata-ir 0.7.0",
  "sp-runtime 39.0.5",
  "sp-staking 36.0.0",
@@ -4231,7 +4226,7 @@ dependencies = [
  "sp-debug-derive",
  "sp-genesis-builder 0.17.0",
  "sp-inherents 36.0.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-metadata-ir 0.10.0",
  "sp-runtime 41.1.0",
  "sp-staking 38.0.0",
@@ -4261,7 +4256,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sp-crypto-hashing",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4282,7 +4277,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sp-crypto-hashing",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4295,7 +4290,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4306,7 +4301,7 @@ checksum = "ed971c6435503a099bdac99fe4c5bea08981709e5b5a0a8535a1856f48561191"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4323,7 +4318,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
  "sp-std",
  "sp-version 37.0.0",
@@ -4344,7 +4339,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-version 39.0.0",
  "sp-weights",
@@ -4473,7 +4468,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4534,9 +4529,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
@@ -4663,9 +4658,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -4867,9 +4862,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -4877,6 +4872,7 @@ dependencies = [
  "http",
  "http-body",
  "hyper",
+ "libc",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -4901,9 +4897,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.62"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2fd658b06e56721792c5df4475705b6cda790e9298d19d2f8af083457bcd127"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -5038,7 +5034,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5141,7 +5137,7 @@ checksum = "a0eb5a3343abf848c0984fe4604b2b105da9539376e24fc0a3b0007411ae4fd9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5182,12 +5178,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
  "serde",
 ]
 
@@ -5218,7 +5214,7 @@ dependencies = [
  "parity-scale-codec",
  "polkavm-derive 0.22.0",
  "scale-info",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime-interface 29.0.1",
  "staging-xcm 16.1.0",
 ]
@@ -5252,7 +5248,7 @@ dependencies = [
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5269,7 +5265,7 @@ dependencies = [
  "pallet-revive-uapi 0.4.0",
  "parity-scale-codec",
  "secp256k1 0.30.0",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "sha3",
 ]
 
@@ -5299,9 +5295,9 @@ dependencies = [
  "scale-info",
  "schnorrkel",
  "secp256k1 0.30.0",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "sha3",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime-interface 29.0.1",
  "staging-xcm 16.1.0",
  "static_assertions",
@@ -5321,7 +5317,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha3",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5336,8 +5332,8 @@ dependencies = [
  "parity-scale-codec",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
- "synstructure 0.13.1",
+ "syn 2.0.101",
+ "synstructure 0.13.2",
 ]
 
 [[package]]
@@ -5371,7 +5367,7 @@ version = "6.0.0-alpha"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17a3ec41989815c27b52e7f653e7f9d6560e34d3708dd2f410b5fd7fd952ce34"
 dependencies = [
- "alloy-sol-types 1.0.0",
+ "alloy-sol-types 1.1.0",
  "cfg-if",
  "derive_more 2.0.1",
  "impl-trait-for-tuples",
@@ -5388,7 +5384,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime-interface 29.0.1",
  "xxhash-rust",
 ]
@@ -5423,7 +5419,7 @@ dependencies = [
  "ink_primitives",
  "parity-scale-codec",
  "scale-info",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime-interface 29.0.1",
 ]
 
@@ -5545,10 +5541,11 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jobserver"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
+ "getrandom 0.3.2",
  "libc",
 ]
 
@@ -5684,7 +5681,7 @@ dependencies = [
  "elliptic-curve",
  "once_cell",
  "serdect",
- "sha2 0.10.8",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -5748,15 +5745,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.171"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libm"
-version = "0.2.11"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+checksum = "c9627da5196e5d8ed0b0495e61e518847578da83483c37288316d9b2e03a7f72"
 
 [[package]]
 name = "libredox"
@@ -5843,7 +5840,7 @@ checksum = "71a98813fa0073a317ed6a8055dcd4722a49d9b862af828ee68449adb799b6be"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5869,9 +5866,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe7db12097d22ec582439daf8618b8fdd1a7bef6270e9af3b1ebcd30893cf413"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -5910,7 +5907,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
 ]
 
 [[package]]
@@ -5930,7 +5927,7 @@ checksum = "1b27834086c65ec3f9387b096d66e99f221cf081c2b738042aa252bcd41204e3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5942,7 +5939,7 @@ dependencies = [
  "macro_magic_core",
  "macro_magic_macros",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5956,7 +5953,7 @@ dependencies = [
  "macro_magic_core_macros",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5967,7 +5964,7 @@ checksum = "b02abfe41815b5bd98dbd4260173db2c116dda171dc0fe7838cb206333b83308"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5978,7 +5975,7 @@ checksum = "73ea28ee64b88876bf45277ed9a5817c1817df061a74f2b988971a12570e5869"
 dependencies = [
  "macro_magic_core",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6059,9 +6056,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.5"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3e04debbb59698c15bacbb6d93584a8c0ca9cc3213cb423d31f760d8843ce5"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
 ]
@@ -6203,7 +6200,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6359,7 +6356,7 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-crypto-hashing",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
 ]
 
@@ -6378,7 +6375,7 @@ dependencies = [
  "sp-api 34.0.0",
  "sp-arithmetic",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
 ]
 
@@ -6397,7 +6394,7 @@ dependencies = [
  "sp-api 36.0.1",
  "sp-arithmetic",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
 ]
 
@@ -6416,7 +6413,7 @@ dependencies = [
  "scale-info",
  "sp-arithmetic",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
 ]
 
@@ -6464,7 +6461,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
 ]
 
@@ -6512,7 +6509,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
 ]
 
@@ -6581,7 +6578,7 @@ dependencies = [
  "sp-application-crypto 38.0.0",
  "sp-consensus-babe 0.40.0",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
  "sp-session",
  "sp-staking 36.0.0",
@@ -6604,7 +6601,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
  "sp-tracing",
 ]
@@ -6666,7 +6663,7 @@ dependencies = [
  "sp-api 34.0.0",
  "sp-consensus-beefy",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
  "sp-state-machine 0.43.0",
 ]
@@ -6685,7 +6682,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
 ]
 
@@ -6809,7 +6806,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
 ]
 
@@ -6846,7 +6843,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
 ]
 
@@ -6889,11 +6886,11 @@ dependencies = [
  "smallvec",
  "sp-api 34.0.0",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
  "sp-std",
- "staging-xcm 14.2.1",
- "staging-xcm-builder 17.0.4",
+ "staging-xcm 14.2.2",
+ "staging-xcm-builder 17.0.5",
  "wasm-instrument",
  "wasmi",
 ]
@@ -6924,25 +6921,25 @@ dependencies = [
  "scale-info",
  "sp-api 34.0.0",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-keystore 0.40.0",
  "sp-runtime 39.0.5",
  "sp-tracing",
- "staging-xcm 14.2.1",
- "staging-xcm-builder 17.0.4",
- "staging-xcm-executor 17.0.1",
+ "staging-xcm 14.2.2",
+ "staging-xcm-builder 17.0.5",
+ "staging-xcm-executor 17.0.2",
  "xcm-simulator",
 ]
 
 [[package]]
 name = "pallet-contracts-proc-macro"
-version = "23.0.2"
+version = "23.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3170e2f4a3d95f2ace274b703a72630294f0a27c687a4adbad9590e2b3e5fe82"
+checksum = "e35aaa3d7f1dba4ea7b74d7015e6068b753d1f7f63b39a4ce6377de1bc51b476"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6970,7 +6967,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "serde",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
 ]
 
@@ -6989,7 +6986,7 @@ dependencies = [
  "scale-info",
  "sp-arithmetic",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
 ]
 
@@ -7004,7 +7001,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
  "sp-staking 36.0.0",
 ]
@@ -7023,7 +7020,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
 ]
 
@@ -7039,7 +7036,7 @@ dependencies = [
  "pallet-balances",
  "parity-scale-codec",
  "scale-info",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
 ]
 
@@ -7060,7 +7057,7 @@ dependencies = [
  "scale-info",
  "sp-arithmetic",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-npos-elections",
  "sp-runtime 39.0.5",
  "strum 0.26.3",
@@ -7093,7 +7090,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-npos-elections",
  "sp-runtime 39.0.5",
  "sp-staking 36.0.0",
@@ -7113,7 +7110,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
  "sp-staking 36.0.0",
 ]
@@ -7133,7 +7130,7 @@ dependencies = [
  "scale-info",
  "sp-core 34.0.0",
  "sp-inherents 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
 ]
 
@@ -7154,7 +7151,7 @@ dependencies = [
  "sp-application-crypto 38.0.0",
  "sp-consensus-grandpa",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
  "sp-session",
  "sp-staking 36.0.0",
@@ -7173,7 +7170,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
 ]
 
@@ -7192,7 +7189,7 @@ dependencies = [
  "scale-info",
  "sp-application-crypto 38.0.0",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
  "sp-staking 36.0.0",
 ]
@@ -7209,7 +7206,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-keyring 39.0.0",
  "sp-runtime 39.0.5",
 ]
@@ -7255,7 +7252,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
 ]
 
@@ -7274,7 +7271,7 @@ dependencies = [
  "scale-info",
  "sp-arithmetic",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
  "sp-weights",
 ]
@@ -7312,7 +7309,7 @@ dependencies = [
  "serde",
  "sp-application-crypto 38.0.0",
  "sp-arithmetic",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-mixnet",
  "sp-runtime 39.0.5",
 ]
@@ -7330,7 +7327,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-mmr-primitives",
  "sp-runtime 39.0.5",
 ]
@@ -7347,7 +7344,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
 ]
 
@@ -7382,7 +7379,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
 ]
 
@@ -7425,7 +7422,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
 ]
 
@@ -7442,7 +7439,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
  "sp-staking 36.0.0",
  "sp-tracing",
@@ -7534,7 +7531,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-metadata-ir 0.7.0",
  "sp-runtime 39.0.5",
 ]
@@ -7570,7 +7567,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
 ]
 
@@ -7585,7 +7582,7 @@ dependencies = [
  "frame-system 38.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
 ]
 
@@ -7604,7 +7601,7 @@ dependencies = [
  "scale-info",
  "sp-arithmetic",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
 ]
 
@@ -7619,7 +7616,7 @@ dependencies = [
  "frame-system 38.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
 ]
 
@@ -7637,7 +7634,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-arithmetic",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
 ]
 
@@ -7654,7 +7651,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
 ]
 
@@ -7682,11 +7679,11 @@ dependencies = [
  "serde",
  "sp-api 34.0.0",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
  "sp-std",
- "staging-xcm 14.2.1",
- "staging-xcm-builder 17.0.4",
+ "staging-xcm 14.2.2",
+ "staging-xcm-builder 17.0.5",
 ]
 
 [[package]]
@@ -7696,7 +7693,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "895fe6f50f621a69132697b8b43d29d1db4d9ff445eec410bf1fc98cd7e9412c"
 dependencies = [
  "alloy-core",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "environmental",
  "ethabi-decode 2.0.0",
  "ethereum-types 0.15.1",
@@ -7728,10 +7725,10 @@ dependencies = [
  "sp-consensus-babe 0.42.1",
  "sp-consensus-slots 0.42.1",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "staging-xcm 16.1.0",
- "staging-xcm-builder 20.0.0",
+ "staging-xcm-builder 20.1.0",
  "substrate-bn",
  "subxt-signer",
 ]
@@ -7748,7 +7745,7 @@ dependencies = [
  "polkavm-linker 0.10.0",
  "sp-runtime 39.0.5",
  "tempfile",
- "toml 0.8.20",
+ "toml 0.8.22",
 ]
 
 [[package]]
@@ -7762,8 +7759,8 @@ dependencies = [
  "pallet-revive-uapi 0.4.0",
  "polkavm-linker 0.21.0",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
- "toml 0.8.20",
+ "sp-io 40.0.1",
+ "toml 0.8.22",
 ]
 
 [[package]]
@@ -7791,13 +7788,13 @@ dependencies = [
  "scale-info",
  "sp-api 34.0.0",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-keystore 0.40.0",
  "sp-runtime 39.0.5",
  "sp-tracing",
- "staging-xcm 14.2.1",
- "staging-xcm-builder 17.0.4",
- "staging-xcm-executor 17.0.1",
+ "staging-xcm 14.2.2",
+ "staging-xcm-builder 17.0.5",
+ "staging-xcm-executor 17.0.2",
  "xcm-simulator",
 ]
 
@@ -7809,7 +7806,7 @@ checksum = "b8aee42afa416be6324cf6650c137da9742f27dc7be3c7ed39ad9748baf3b9ae"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7820,7 +7817,7 @@ checksum = "63c2dc2fc6961da23fefc54689ce81a8e006f6988bc465dcc9ab9db905d31766"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -7876,7 +7873,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
 ]
 
@@ -7914,7 +7911,7 @@ dependencies = [
  "scale-info",
  "sp-arithmetic",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
 ]
 
@@ -7931,7 +7928,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
  "sp-weights",
 ]
@@ -7946,7 +7943,7 @@ dependencies = [
  "frame-system 38.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
 ]
 
@@ -7964,7 +7961,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
  "sp-session",
  "sp-staking 36.0.0",
@@ -8016,7 +8013,7 @@ dependencies = [
  "rand_chacha 0.3.1",
  "scale-info",
  "sp-arithmetic",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
 ]
 
@@ -8037,16 +8034,16 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-application-crypto 38.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
  "sp-staking 36.0.0",
 ]
 
 [[package]]
 name = "pallet-staking-reward-fn"
-version = "22.0.0"
+version = "22.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "988a7ebeacc84d4bdb0b12409681e956ffe35438447d8f8bc78db547cffb6ebc"
+checksum = "4b982dbfe9fbc548dc7f9a3078214989ed58cabf521a8313ae1767d6b4b53b9b"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -8076,7 +8073,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
 ]
 
@@ -8093,7 +8090,7 @@ dependencies = [
  "scale-info",
  "sp-api 34.0.0",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
  "sp-statement-store",
 ]
@@ -8110,7 +8107,7 @@ dependencies = [
  "frame-system 38.0.0",
  "parity-scale-codec",
  "scale-info",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
 ]
 
@@ -8128,7 +8125,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-inherents 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
  "sp-storage 21.0.0",
  "sp-timestamp 34.0.0",
@@ -8149,7 +8146,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
 ]
 
@@ -8165,7 +8162,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
 ]
 
@@ -8182,7 +8179,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
 ]
 
@@ -8214,7 +8211,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-inherents 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
  "sp-transaction-storage-proof",
 ]
@@ -8283,7 +8280,7 @@ dependencies = [
  "parity-scale-codec",
  "scale-info",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
 ]
 
@@ -8333,32 +8330,31 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
- "staging-xcm 14.2.1",
- "staging-xcm-builder 17.0.4",
- "staging-xcm-executor 17.0.1",
+ "staging-xcm 14.2.2",
+ "staging-xcm-builder 17.0.5",
+ "staging-xcm-executor 17.0.2",
  "tracing",
  "xcm-runtime-apis",
 ]
 
 [[package]]
 name = "pallet-xcm-benchmarks"
-version = "17.0.0"
+version = "17.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2da423463933b42f4a4c74175f9e9295a439de26719579b894ce533926665e4a"
+checksum = "05bfc67610a37d0bd98487b82edfbf9629d3a9699b52d5758e9d64cf78b3b7ae"
 dependencies = [
  "frame-benchmarking 38.0.0",
  "frame-support 38.2.0",
  "frame-system 38.0.0",
- "log",
  "parity-scale-codec",
  "scale-info",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
- "staging-xcm 14.2.1",
- "staging-xcm-builder 17.0.4",
- "staging-xcm-executor 17.0.1",
+ "staging-xcm 14.2.2",
+ "staging-xcm-builder 17.0.5",
+ "staging-xcm-executor 17.0.2",
 ]
 
 [[package]]
@@ -8379,9 +8375,9 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-runtime 39.0.5",
  "sp-std",
- "staging-xcm 14.2.1",
- "staging-xcm-builder 17.0.4",
- "staging-xcm-executor 17.0.1",
+ "staging-xcm 14.2.2",
+ "staging-xcm-builder 17.0.5",
+ "staging-xcm-executor 17.0.2",
 ]
 
 [[package]]
@@ -8400,8 +8396,8 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-runtime 39.0.5",
  "sp-std",
- "staging-xcm 14.2.1",
- "staging-xcm-builder 17.0.4",
+ "staging-xcm 14.2.2",
+ "staging-xcm-builder 17.0.5",
 ]
 
 [[package]]
@@ -8427,11 +8423,11 @@ dependencies = [
  "scale-info",
  "sp-consensus-aura 0.40.0",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
  "staging-parachain-info",
- "staging-xcm 14.2.1",
- "staging-xcm-executor 17.0.1",
+ "staging-xcm 14.2.2",
+ "staging-xcm-executor 17.0.2",
  "substrate-wasm-builder",
 ]
 
@@ -8457,12 +8453,12 @@ dependencies = [
  "polkadot-parachain-primitives 14.0.0",
  "sp-consensus-aura 0.40.0",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
  "sp-tracing",
  "staging-parachain-info",
- "staging-xcm 14.2.1",
- "staging-xcm-executor 17.0.1",
+ "staging-xcm 14.2.2",
+ "staging-xcm-executor 17.0.2",
  "substrate-wasm-builder",
 ]
 
@@ -8511,7 +8507,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -8640,7 +8636,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -8723,7 +8719,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52b5648a2e8ce1f9a0f8c41c38def670cefd91932cd793468e1a5b0b0b4e4af1"
 dependencies = [
  "bounded-collections",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "parity-scale-codec",
  "polkadot-core-primitives 15.0.0",
  "scale-info",
@@ -8740,7 +8736,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72943c0948c686b47bacb1a03e59baff63bfba2e16e208d77f0f8615827f8564"
 dependencies = [
  "bounded-collections",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "parity-scale-codec",
  "polkadot-core-primitives 17.1.0",
  "scale-info",
@@ -8771,7 +8767,7 @@ dependencies = [
  "sp-consensus-slots 0.40.1",
  "sp-core 34.0.0",
  "sp-inherents 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-keystore 0.40.0",
  "sp-runtime 39.0.5",
  "sp-staking 34.0.0",
@@ -8798,7 +8794,7 @@ dependencies = [
  "sp-consensus-slots 0.40.1",
  "sp-core 34.0.0",
  "sp-inherents 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-keystore 0.40.0",
  "sp-runtime 39.0.5",
  "sp-staking 36.0.0",
@@ -8806,9 +8802,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-common"
-version = "17.0.0"
+version = "17.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc15154ba5ca55d323fcf7af0f5dcd39d58dcb4dfac3d9b30404840a6d8bbde4"
+checksum = "1aaafdb12ef0cc23912bd71cdd636f62831be0c359d55d310bb30b72e72ac7ee"
 dependencies = [
  "bitvec",
  "frame-benchmarking 38.0.0",
@@ -8843,14 +8839,14 @@ dependencies = [
  "sp-api 34.0.0",
  "sp-core 34.0.0",
  "sp-inherents 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-npos-elections",
  "sp-runtime 39.0.5",
  "sp-session",
  "sp-staking 36.0.0",
- "staging-xcm 14.2.1",
- "staging-xcm-builder 17.0.4",
- "staging-xcm-executor 17.0.1",
+ "staging-xcm 14.2.2",
+ "staging-xcm-builder 17.0.5",
+ "staging-xcm-executor 17.0.2",
  "static_assertions",
 ]
 
@@ -8875,7 +8871,7 @@ checksum = "1d4cdf181c2419b35c2cbde813da2d8ee777b69b4a6fa346b962d144e3521976"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "frame-benchmarking 38.0.0",
  "frame-support 38.2.0",
  "frame-system 38.0.0",
@@ -8906,14 +8902,14 @@ dependencies = [
  "sp-arithmetic",
  "sp-core 34.0.0",
  "sp-inherents 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-keystore 0.40.0",
  "sp-runtime 39.0.5",
  "sp-session",
  "sp-staking 36.0.0",
  "sp-std",
- "staging-xcm 14.2.1",
- "staging-xcm-executor 17.0.1",
+ "staging-xcm 14.2.2",
+ "staging-xcm-executor 17.0.2",
 ]
 
 [[package]]
@@ -9115,7 +9111,7 @@ dependencies = [
  "sp-externalities 0.29.0",
  "sp-genesis-builder 0.15.1",
  "sp-inherents 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-keyring 39.0.0",
  "sp-keystore 0.40.0",
  "sp-metadata-ir 0.7.0",
@@ -9140,9 +9136,9 @@ dependencies = [
  "sp-wasm-interface",
  "sp-weights",
  "staging-parachain-info",
- "staging-xcm 14.2.1",
- "staging-xcm-builder 17.0.4",
- "staging-xcm-executor 17.0.1",
+ "staging-xcm 14.2.2",
+ "staging-xcm-builder 17.0.5",
+ "staging-xcm-executor 17.0.2",
  "substrate-bip39",
  "testnet-parachains-constants",
  "xcm-runtime-apis",
@@ -9172,7 +9168,7 @@ dependencies = [
  "sp-consensus-grandpa",
  "sp-core 34.0.0",
  "sp-inherents 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-offchain",
  "sp-runtime 39.0.5",
  "sp-session",
@@ -9343,7 +9339,7 @@ dependencies = [
  "polkavm-common 0.9.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -9355,7 +9351,7 @@ dependencies = [
  "polkavm-common 0.10.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -9367,7 +9363,7 @@ dependencies = [
  "polkavm-common 0.18.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -9379,7 +9375,7 @@ dependencies = [
  "polkavm-common 0.21.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -9391,7 +9387,7 @@ dependencies = [
  "polkavm-common 0.22.0",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -9401,7 +9397,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ba81f7b5faac81e528eb6158a6f3c9e0bb1008e0ffa19653bc8dea925ecb429"
 dependencies = [
  "polkavm-derive-impl 0.9.0",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -9411,7 +9407,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9324fe036de37c17829af233b46ef6b5562d4a0c09bb7fdb9f8378856dee30cf"
 dependencies = [
  "polkavm-derive-impl 0.10.0",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -9421,7 +9417,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c16669ddc7433e34c1007d31080b80901e3e8e523cb9d4b441c3910cf9294b"
 dependencies = [
  "polkavm-derive-impl 0.18.1",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -9431,7 +9427,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36837f6b7edfd6f4498f8d25d81da16cf03bd6992c3e56f3d477dfc90f4fefca"
 dependencies = [
  "polkavm-derive-impl 0.21.0",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -9441,7 +9437,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad6a5df4cc6466a219386b04d8bd267ba772f9458a8e9aa7539757ca5b11e2aa"
 dependencies = [
  "polkavm-derive-impl 0.22.0",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -9574,7 +9570,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.24",
+ "zerocopy 0.8.25",
 ]
 
 [[package]]
@@ -9619,12 +9615,12 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.31"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5316f57387668042f561aae71480de936257848f9c43ce528e311d89a07cadeb"
+checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
 dependencies = [
  "proc-macro2",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -9708,7 +9704,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -9719,14 +9715,14 @@ checksum = "75eea531cfcd120e0851a3f8aed42c4841f78c889eefafd96339c72677ae42c3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.94"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -9753,9 +9749,9 @@ dependencies = [
 
 [[package]]
 name = "psm"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f58e5423e24c18cc840e1c98370b3993c6649cd1678b4d24318bcf0a083cbe88"
+checksum = "6e944464ec8536cd1beb0bbfd96987eb5e3b72f2ecdafdc5c769a37f1fa2ae1f"
 dependencies = [
  "cc",
 ]
@@ -9821,14 +9817,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.3",
  "serde",
- "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -9857,7 +9852,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -9907,9 +9902,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b8c0c260b63a8219631167be35e6a988e9554dbd323f8bd08439c8ed1302bd1"
+checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
  "bitflags 2.9.0",
 ]
@@ -9920,7 +9915,7 @@ version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libredox",
  "thiserror 1.0.69",
 ]
@@ -9942,7 +9937,7 @@ checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -10092,7 +10087,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -10169,8 +10164,8 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-runtime 39.0.5",
  "sp-weights",
- "staging-xcm 14.2.1",
- "staging-xcm-builder 17.0.4",
+ "staging-xcm 14.2.2",
+ "staging-xcm-builder 17.0.5",
 ]
 
 [[package]]
@@ -10192,7 +10187,7 @@ dependencies = [
  "primitive-types 0.12.2",
  "proptest",
  "rand 0.8.5",
- "rand 0.9.0",
+ "rand 0.9.1",
  "rlp 0.5.2",
  "ruint-macro",
  "serde",
@@ -10302,22 +10297,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.3"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e56a18552996ac8d29ecc3b190b4fdbb2d91ca4ec396de7bbffaf43f3d637e96"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
  "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys 0.9.3",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.25"
+version = "0.23.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c"
+checksum = "df51b5869f3a441595eac5e8ff14d486ff285f7b8c0df8770e49c3b56351f0f0"
 dependencies = [
  "log",
  "once_cell",
@@ -10348,9 +10343,9 @@ checksum = "917ce264624a4b4db1c364dcc35bfca9ded014d0a958cd47ad3e960e988ea51c"
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5467026f437b4cb2a533865eaa73eb840019a0916f4b9ec563c6e617e086c9"
+checksum = "4937d110d34408e9e5ad30ba0b0ca3b6a8a390f8db3636db60144ac4fa792750"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",
@@ -10409,7 +10404,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5174a470eeb535a721ae9fdd6e291c2411a906b96592182d05217591d5c5cf7b"
 dependencies = [
  "byteorder",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
 ]
 
 [[package]]
@@ -10481,7 +10476,7 @@ dependencies = [
  "sp-api 34.0.0",
  "sp-core 34.0.0",
  "sp-externalities 0.29.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-panic-handler",
  "sp-runtime-interface 28.0.0",
  "sp-trie 37.0.0",
@@ -10571,7 +10566,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -10599,7 +10594,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -10626,7 +10621,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -10648,7 +10643,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scale-info",
- "syn 2.0.100",
+ "syn 2.0.101",
  "thiserror 1.0.69",
 ]
 
@@ -10702,7 +10697,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -10730,7 +10725,7 @@ dependencies = [
  "merlin",
  "rand_core 0.6.4",
  "serde_bytes",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "subtle",
  "zeroize",
 ]
@@ -10756,7 +10751,7 @@ dependencies = [
  "password-hash",
  "pbkdf2",
  "salsa20",
- "sha2 0.10.8",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -10963,7 +10958,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -10974,7 +10969,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -10997,7 +10992,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -11031,7 +11026,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -11074,9 +11069,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -11114,9 +11109,9 @@ dependencies = [
 
 [[package]]
 name = "shared_child"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09fa9338aed9a1df411814a5b2252f7cd206c55ae9bf2fa763f8de84603aa60c"
+checksum = "7e297bd52991bbe0686c086957bee142f13df85d1e79b0b21630a99d374ae9dc"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -11151,9 +11146,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.2"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
 ]
@@ -11228,9 +11223,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "smol"
@@ -11264,7 +11259,7 @@ dependencies = [
  "bs58",
  "chacha20",
  "crossbeam-queue",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "ed25519-zebra",
  "either",
  "event-listener",
@@ -11291,7 +11286,7 @@ dependencies = [
  "schnorrkel",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "sha3",
  "siphasher",
  "slab",
@@ -11314,7 +11309,7 @@ dependencies = [
  "base64 0.22.1",
  "blake2-rfc",
  "bs58",
- "derive_more 0.99.19",
+ "derive_more 0.99.20",
  "either",
  "event-listener",
  "fnv",
@@ -11365,7 +11360,7 @@ dependencies = [
  "snowbridge-ethereum",
  "snowbridge-milagro-bls",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
  "sp-std",
  "ssz_rs",
@@ -11389,11 +11384,11 @@ dependencies = [
  "snowbridge-beacon-primitives",
  "sp-arithmetic",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
  "sp-std",
- "staging-xcm 14.2.1",
- "staging-xcm-builder 17.0.4",
+ "staging-xcm 14.2.2",
+ "staging-xcm-builder 17.0.5",
 ]
 
 [[package]]
@@ -11412,7 +11407,7 @@ dependencies = [
  "scale-info",
  "serde",
  "serde-big-array",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
  "sp-std",
 ]
@@ -11477,7 +11472,7 @@ dependencies = [
  "snowbridge-ethereum",
  "snowbridge-pallet-ethereum-client-fixtures",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
  "sp-std",
  "static_assertions",
@@ -11517,11 +11512,11 @@ dependencies = [
  "snowbridge-pallet-inbound-queue-fixtures",
  "snowbridge-router-primitives",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
  "sp-std",
- "staging-xcm 14.2.1",
- "staging-xcm-executor 17.0.1",
+ "staging-xcm 14.2.2",
+ "staging-xcm-executor 17.0.2",
 ]
 
 [[package]]
@@ -11555,7 +11550,7 @@ dependencies = [
  "snowbridge-outbound-queue-merkle-tree",
  "sp-arithmetic",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
  "sp-std",
 ]
@@ -11574,11 +11569,11 @@ dependencies = [
  "scale-info",
  "snowbridge-core",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
  "sp-std",
- "staging-xcm 14.2.1",
- "staging-xcm-executor 17.0.1",
+ "staging-xcm 14.2.2",
+ "staging-xcm-executor 17.0.2",
 ]
 
 [[package]]
@@ -11594,11 +11589,11 @@ dependencies = [
  "scale-info",
  "snowbridge-core",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
  "sp-std",
- "staging-xcm 14.2.1",
- "staging-xcm-executor 17.0.1",
+ "staging-xcm 14.2.2",
+ "staging-xcm-executor 17.0.2",
 ]
 
 [[package]]
@@ -11613,9 +11608,9 @@ dependencies = [
  "snowbridge-core",
  "sp-arithmetic",
  "sp-std",
- "staging-xcm 14.2.1",
- "staging-xcm-builder 17.0.4",
- "staging-xcm-executor 17.0.1",
+ "staging-xcm 14.2.2",
+ "staging-xcm-builder 17.0.5",
+ "staging-xcm-executor 17.0.2",
 ]
 
 [[package]]
@@ -11642,12 +11637,12 @@ dependencies = [
  "snowbridge-pallet-outbound-queue",
  "snowbridge-pallet-system",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-keyring 39.0.0",
  "sp-runtime 39.0.5",
  "staging-parachain-info",
- "staging-xcm 14.2.1",
- "staging-xcm-executor 17.0.1",
+ "staging-xcm 14.2.2",
+ "staging-xcm-executor 17.0.2",
 ]
 
 [[package]]
@@ -11660,14 +11655,14 @@ dependencies = [
  "snowbridge-core",
  "sp-api 34.0.0",
  "sp-std",
- "staging-xcm 14.2.1",
+ "staging-xcm 14.2.2",
 ]
 
 [[package]]
 name = "socket2"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -11746,7 +11741,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -11761,7 +11756,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -11774,7 +11769,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
 ]
 
 [[package]]
@@ -11787,7 +11782,7 @@ dependencies = [
  "scale-info",
  "serde",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
 ]
 
 [[package]]
@@ -11915,7 +11910,7 @@ dependencies = [
  "sp-application-crypto 38.0.0",
  "sp-core 34.0.0",
  "sp-crypto-hashing",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-keystore 0.40.0",
  "sp-mmr-primitives",
  "sp-runtime 39.0.5",
@@ -12111,7 +12106,7 @@ dependencies = [
  "blake2b_simd",
  "byteorder",
  "digest 0.10.7",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "sha3",
  "twox-hash",
 ]
@@ -12124,7 +12119,7 @@ checksum = "b85d0f1f1e44bd8617eb2a48203ee854981229e3e79e6f468c7175d5fd37489b"
 dependencies = [
  "quote",
  "sp-crypto-hashing",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -12135,7 +12130,7 @@ checksum = "48d09fa0a5f7299fb81ee25ae3853d26200f7a348148aed6de76be905c007dbe"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -12216,9 +12211,9 @@ dependencies = [
 
 [[package]]
 name = "sp-io"
-version = "38.0.0"
+version = "38.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ef7eb561bb4839cc8424ce58c5ea236cbcca83f26fcc0426d8decfe8aa97d4"
+checksum = "61e20e9d9fe236466c1e38add64b591237c58540a07408407869d52d0e79fd18"
 dependencies = [
  "bytes",
  "docify",
@@ -12243,9 +12238,9 @@ dependencies = [
 
 [[package]]
 name = "sp-io"
-version = "40.0.0"
+version = "40.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5d93ea3512cf361577719bab161e46eb04d3abd8563e32bdf5df4a42aea0ba"
+checksum = "3e41d010bcc515d119901ff7ac83150c335d543c7f6c03be5c8fe08430b8a03b"
 dependencies = [
  "bytes",
  "docify",
@@ -12432,7 +12427,7 @@ dependencies = [
  "sp-application-crypto 38.0.0",
  "sp-arithmetic",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-std",
  "sp-weights",
  "tracing",
@@ -12460,7 +12455,7 @@ dependencies = [
  "sp-application-crypto 40.1.0",
  "sp-arithmetic",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-std",
  "sp-trie 39.1.0",
  "sp-weights",
@@ -12519,7 +12514,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -12634,7 +12629,7 @@ dependencies = [
  "parity-scale-codec",
  "rand 0.8.5",
  "scale-info",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "sp-api 34.0.0",
  "sp-application-crypto 38.0.0",
  "sp-core 34.0.0",
@@ -12833,7 +12828,7 @@ dependencies = [
  "parity-scale-codec",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -12846,7 +12841,7 @@ dependencies = [
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -12953,9 +12948,9 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm"
-version = "14.2.1"
+version = "14.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "250c5290c308d1f462403dc4e7926976727917e98a196de1ea4a49c86341f21c"
+checksum = "f3f66daa99c90c4b1443696ce42f38aa9d47954ae6270301be42f049a1bf0ba5"
 dependencies = [
  "array-bytes",
  "bounded-collections",
@@ -12995,9 +12990,9 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-builder"
-version = "17.0.4"
+version = "17.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1693870a07e3fd8115c02b44e1223ce149b6cfa0b60f59a1c0fbc26637766a5"
+checksum = "d6036361f3435769cbb3e2423d186cf32cc4aaa88ab2781606c0b67a6bb20a89"
 dependencies = [
  "frame-support 38.2.0",
  "frame-system 38.0.0",
@@ -13009,18 +13004,18 @@ dependencies = [
  "polkadot-parachain-primitives 14.0.0",
  "scale-info",
  "sp-arithmetic",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
  "sp-weights",
- "staging-xcm 14.2.1",
- "staging-xcm-executor 17.0.1",
+ "staging-xcm 14.2.2",
+ "staging-xcm-executor 17.0.2",
 ]
 
 [[package]]
 name = "staging-xcm-builder"
-version = "20.0.0"
+version = "20.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e041eaa60fc0df3dbaa5779959f5eaac9c1b81d045a5a1792479e46dfd31f028"
+checksum = "3fdd44a74a38339c423f690900678a1b5a31d0a44d8e01a0f445a64c96ec3175"
 dependencies = [
  "environmental",
  "frame-support 40.1.0",
@@ -13033,7 +13028,7 @@ dependencies = [
  "scale-info",
  "sp-arithmetic",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-weights",
  "staging-xcm 16.1.0",
@@ -13043,9 +13038,9 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-executor"
-version = "17.0.1"
+version = "17.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c89045f495097293ce29df1f3f459e9ccc991ff2ee88a4a91e8110a6886d2c8"
+checksum = "7564cee33c808c1b543ac915fcd47ff5a77bcff6303bf56d59ffdbed2dd5ce1c"
 dependencies = [
  "environmental",
  "frame-benchmarking 38.0.0",
@@ -13055,10 +13050,10 @@ dependencies = [
  "scale-info",
  "sp-arithmetic",
  "sp-core 34.0.0",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
  "sp-weights",
- "staging-xcm 14.2.1",
+ "staging-xcm 14.2.2",
  "tracing",
 ]
 
@@ -13076,7 +13071,7 @@ dependencies = [
  "scale-info",
  "sp-arithmetic",
  "sp-core 36.1.0",
- "sp-io 40.0.0",
+ "sp-io 40.0.1",
  "sp-runtime 41.1.0",
  "sp-weights",
  "staging-xcm 16.1.0",
@@ -13154,7 +13149,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -13166,7 +13161,7 @@ dependencies = [
  "hmac 0.12.1",
  "pbkdf2",
  "schnorrkel",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "zeroize",
 ]
 
@@ -13191,9 +13186,9 @@ checksum = "b285e7d183a32732fdc119f3d81b7915790191fad602b7c709ef247073c77a2e"
 
 [[package]]
 name = "substrate-wasm-builder"
-version = "24.0.1"
+version = "24.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf035ffe7335fb24053edfe4d0a5780250eda772082a1b80ae25835dd4c09265"
+checksum = "8eccd97d503bdd5d14be243fefccc4b712f8740aab2baba3dfd0140e2d08f765"
 dependencies = [
  "build-helper",
  "cargo_metadata 0.15.4",
@@ -13205,7 +13200,7 @@ dependencies = [
  "sp-maybe-compressed-blob",
  "strum 0.26.3",
  "tempfile",
- "toml 0.8.20",
+ "toml 0.8.22",
  "walkdir",
  "wasm-opt",
 ]
@@ -13266,7 +13261,7 @@ dependencies = [
  "scale-info",
  "scale-typegen",
  "subxt-metadata",
- "syn 2.0.100",
+ "syn 2.0.101",
  "thiserror 1.0.69",
 ]
 
@@ -13329,7 +13324,7 @@ dependencies = [
  "scale-typegen",
  "subxt-codegen",
  "subxt-utils-fetchmetadata",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -13370,7 +13365,7 @@ dependencies = [
  "secrecy 0.10.3",
  "serde",
  "serde_json",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "subxt-core",
  "zeroize",
 ]
@@ -13399,9 +13394,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.100"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -13417,7 +13412,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -13429,19 +13424,19 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "syn-solidity"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34c9c96de1f835488c1501092847b522be88c9ac6fb0d4c0fbea92992324c8f4"
+checksum = "3d0f0d4760f4c2a0823063b2c70e97aa2ad185f57be195172ccc0e23c4b787c4"
 dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -13467,13 +13462,13 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -13497,7 +13492,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.2",
  "once_cell",
- "rustix 1.0.3",
+ "rustix 1.0.7",
  "windows-sys 0.59.0",
 ]
 
@@ -13538,7 +13533,7 @@ dependencies = [
  "rococo-runtime-constants",
  "smallvec",
  "sp-runtime 39.0.5",
- "staging-xcm 14.2.1",
+ "staging-xcm 14.2.2",
  "westend-runtime-constants",
 ]
 
@@ -13568,7 +13563,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -13579,7 +13574,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -13681,7 +13676,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -13707,9 +13702,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",
@@ -13730,9 +13725,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.20"
+version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
+checksum = "05ae329d1f08c4d17a59bed7ff5b5a769d062e64a62d34a3261b219e62cd5aae"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -13742,25 +13737,32 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.24"
+version = "0.22.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+checksum = "310068873db2c5b3e7659d2cc35d21855dbafa50d1ce336397c666e3cb08137e"
 dependencies = [
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
+ "toml_write",
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfb942dfe1d8e29a7ee7fcbde5bd2b9a25fb89aa70caea2eba3bee836ff41076"
 
 [[package]]
 name = "tower"
@@ -13809,7 +13811,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -14083,9 +14085,9 @@ checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "w3f-bls"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a3028804c8bbae2a97a15b71ffc0e308c4b01a520994aafa77d56e94e19024"
+checksum = "e6bfb937b3d12077654a9e43e32a4e9c20177dd9fea0f3aba673e7840bb54f32"
 dependencies = [
  "ark-bls12-377",
  "ark-bls12-381 0.4.0",
@@ -14094,14 +14096,12 @@ dependencies = [
  "ark-serialize 0.4.2",
  "ark-serialize-derive 0.4.2",
  "arrayref",
- "constcat",
  "digest 0.10.7",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "sha3",
- "thiserror 1.0.69",
  "zeroize",
 ]
 
@@ -14216,7 +14216,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "wasm-bindgen-shared",
 ]
 
@@ -14251,7 +14251,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -14424,7 +14424,7 @@ dependencies = [
  "log",
  "rustix 0.36.17",
  "serde",
- "sha2 0.10.8",
+ "sha2 0.10.9",
  "toml 0.5.11",
  "windows-sys 0.45.0",
  "zstd 0.11.2+zstd.1.5.2",
@@ -14590,9 +14590,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "0.26.8"
+version = "0.26.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09aed61f5e8d2c18344b3faa33a4c837855fe56642757754775548fee21386c4"
+checksum = "c99403924bc5f23afefc319b8ac67ed0e50669f6e52a413314cccb1fdbc93ba0"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -14610,19 +14610,19 @@ dependencies = [
  "sp-core 34.0.0",
  "sp-runtime 39.0.5",
  "sp-weights",
- "staging-xcm 14.2.1",
- "staging-xcm-builder 17.0.4",
+ "staging-xcm 14.2.2",
+ "staging-xcm-builder 17.0.5",
 ]
 
 [[package]]
 name = "which"
-version = "7.0.2"
+version = "7.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2774c861e1f072b3aadc02f8ba886c26ad6321567ecc294c935434cad06f1283"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
 dependencies = [
  "either",
  "env_home",
- "rustix 0.38.44",
+ "rustix 1.0.7",
  "winsafe",
 ]
 
@@ -14669,11 +14669,37 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
-version = "0.52.0"
+version = "0.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "4763c1de310c86d75a878046489e2e5ba02c649d185f21c67d4cf8a56d098980"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings 0.4.0",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -14689,7 +14715,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
  "windows-result",
- "windows-strings",
+ "windows-strings 0.3.1",
  "windows-targets 0.53.0",
 ]
 
@@ -14707,6 +14733,15 @@ name = "windows-strings"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ba9642430ee452d5a7aa78d72907ebe8cfda358e8cb7918a2050581322f97"
 dependencies = [
  "windows-link",
 ]
@@ -14991,9 +15026,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.4"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
+checksum = "9e27d6ad3dac991091e4d35de9ba2d2d00647c5d0fc26c5496dee55984ae111b"
 dependencies = [
  "memchr",
 ]
@@ -15055,7 +15090,7 @@ dependencies = [
  "Inflector",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -15067,7 +15102,7 @@ dependencies = [
  "Inflector",
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -15081,8 +15116,8 @@ dependencies = [
  "scale-info",
  "sp-api 34.0.0",
  "sp-weights",
- "staging-xcm 14.2.1",
- "staging-xcm-executor 17.0.1",
+ "staging-xcm 14.2.2",
+ "staging-xcm-executor 17.0.2",
 ]
 
 [[package]]
@@ -15100,12 +15135,12 @@ dependencies = [
  "polkadot-primitives 16.0.0",
  "polkadot-runtime-parachains",
  "scale-info",
- "sp-io 38.0.0",
+ "sp-io 38.0.2",
  "sp-runtime 39.0.5",
  "sp-std",
- "staging-xcm 14.2.1",
- "staging-xcm-builder 17.0.4",
- "staging-xcm-executor 17.0.1",
+ "staging-xcm 14.2.2",
+ "staging-xcm-builder 17.0.5",
+ "staging-xcm-executor 17.0.2",
 ]
 
 [[package]]
@@ -15146,8 +15181,8 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
- "synstructure 0.13.1",
+ "syn 2.0.101",
+ "synstructure 0.13.2",
 ]
 
 [[package]]
@@ -15161,11 +15196,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
- "zerocopy-derive 0.8.24",
+ "zerocopy-derive 0.8.25",
 ]
 
 [[package]]
@@ -15176,18 +15211,18 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -15207,8 +15242,8 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
- "synstructure 0.13.1",
+ "syn 2.0.101",
+ "synstructure 0.13.2",
 ]
 
 [[package]]
@@ -15228,7 +15263,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -15250,19 +15285,19 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.100",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "zip"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27c03817464f64e23f6f37574b4fdc8cf65925b5bfd2b0f2aedf959791941f88"
+checksum = "1dcb24d0152526ae49b9b96c1dcf71850ca1e0b882e4e28ed898a93c41334744"
 dependencies = [
  "arbitrary",
  "crc32fast",
  "crossbeam-utils",
- "indexmap 2.8.0",
+ "indexmap 2.9.0",
  "memchr",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5200,7 +5200,8 @@ checksum = "8e04e2fd2b8188ea827b32ef11de88377086d690286ab35747ef7f9bf3ccb590"
 [[package]]
 name = "ink"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#b7e4089869ae055ebd17958e56eefe679b52daea"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a2a508085165973ab4dcc8c46ca0aee3359a7704b409abbe20252d0f1e2993"
 dependencies = [
  "const_format",
  "deranged",
@@ -5212,6 +5213,7 @@ dependencies = [
  "ink_primitives",
  "ink_storage",
  "keccak-const",
+ "linkme",
  "pallet-revive-uapi 0.4.0",
  "parity-scale-codec",
  "polkavm-derive 0.22.0",
@@ -5224,7 +5226,8 @@ dependencies = [
 [[package]]
 name = "ink_allocator"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#b7e4089869ae055ebd17958e56eefe679b52daea"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d00ae3f31ad22cc33a6b376e5d8566107bddf09ca56973ba4ebc224f8f0a94b"
 dependencies = [
  "cfg-if",
 ]
@@ -5232,7 +5235,8 @@ dependencies = [
 [[package]]
 name = "ink_codegen"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#b7e4089869ae055ebd17958e56eefe679b52daea"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206d3415b25222a1bfebd7da562e46d5e6b558e3592fd012636f3ada4fa827b0"
 dependencies = [
  "blake2",
  "derive_more 2.0.1",
@@ -5254,7 +5258,8 @@ dependencies = [
 [[package]]
 name = "ink_engine"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#b7e4089869ae055ebd17958e56eefe679b52daea"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c1a6bd3d01f988a53d4267e3668abc4b30cf82e261d10435ba542911ebdb5a0"
 dependencies = [
  "blake2",
  "derive_more 2.0.1",
@@ -5271,7 +5276,8 @@ dependencies = [
 [[package]]
 name = "ink_env"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#b7e4089869ae055ebd17958e56eefe679b52daea"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b9edaea36cb17fa3a06c79db09077a584977dbf86c657c69c9aa16d6be8da35"
 dependencies = [
  "blake2",
  "cfg-if",
@@ -5280,7 +5286,6 @@ dependencies = [
  "hex-literal 1.0.0",
  "ink_allocator",
  "ink_engine",
- "ink_macro",
  "ink_prelude",
  "ink_primitives",
  "ink_storage_traits",
@@ -5305,7 +5310,8 @@ dependencies = [
 [[package]]
 name = "ink_ir"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#b7e4089869ae055ebd17958e56eefe679b52daea"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa14b3d13f727578a482913defdd2be0412940864b2f8338e3f75a533cfd8090"
 dependencies = [
  "blake2",
  "either",
@@ -5321,7 +5327,8 @@ dependencies = [
 [[package]]
 name = "ink_macro"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#b7e4089869ae055ebd17958e56eefe679b52daea"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a11db85cc52fa780381c6745b18dcfc88f261ba91d5296d34f1d0b51b29d5e0a"
 dependencies = [
  "ink_codegen",
  "ink_ir",
@@ -5336,13 +5343,13 @@ dependencies = [
 [[package]]
 name = "ink_metadata"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#b7e4089869ae055ebd17958e56eefe679b52daea"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa6834afae7c46316787699f8647357c6dd77c7e85d32088f61d326e42d8a3a6"
 dependencies = [
  "derive_more 2.0.1",
  "impl-serde 0.5.0",
  "ink_prelude",
  "ink_primitives",
- "linkme",
  "parity-scale-codec",
  "scale-info",
  "schemars",
@@ -5352,7 +5359,8 @@ dependencies = [
 [[package]]
 name = "ink_prelude"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#b7e4089869ae055ebd17958e56eefe679b52daea"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3f17dd75acf3e30e36b2ffe87f7b11e30e808b09ebfe39408d2fed78c53de3c"
 dependencies = [
  "cfg-if",
 ]
@@ -5360,7 +5368,8 @@ dependencies = [
 [[package]]
 name = "ink_primitives"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#b7e4089869ae055ebd17958e56eefe679b52daea"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17a3ec41989815c27b52e7f653e7f9d6560e34d3708dd2f410b5fd7fd952ce34"
 dependencies = [
  "alloy-sol-types 1.0.0",
  "cfg-if",
@@ -5387,7 +5396,8 @@ dependencies = [
 [[package]]
 name = "ink_storage"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#b7e4089869ae055ebd17958e56eefe679b52daea"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5695273713f25bb939570ccb3925f2dd73d8f6043f60b061b7e4975f20dbc115"
 dependencies = [
  "array-init",
  "cfg-if",
@@ -5405,7 +5415,8 @@ dependencies = [
 [[package]]
 name = "ink_storage_traits"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#b7e4089869ae055ebd17958e56eefe679b52daea"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a29514bfbb6eaaa56c463e04ebabef8af491abeb2414884619a7137b4812d6f"
 dependencies = [
  "ink_metadata",
  "ink_prelude",

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -49,7 +49,7 @@ alloy-json-abi = "0.8.20"
 polkavm-linker = "0.22.0"
 
 contract-metadata = { version = "6.0.0-alpha", path = "../metadata" }
-ink_metadata = { git = "https://github.com/use-ink/ink", branch = "master", default-features = false, features = ["std", "derive"] }
+ink_metadata = { version = "6.0.0-alpha", default-features = false, features = ["std", "derive"] }
 sha3 = "0.10.8"
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/build/templates/new/_Cargo.toml
+++ b/crates/build/templates/new/_Cargo.toml
@@ -5,7 +5,7 @@ authors = ["[your_name] <[your_email]>"]
 edition = "2021"
 
 [dependencies]
-ink = { git = "https://github.com/use-ink/ink", branch = "master", default-features = false, features = ["unstable-hostfn"] }
+ink = { version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 [dev-dependencies]
 ink_e2e = { git = "https://github.com/use-ink/ink", branch = "master" }

--- a/crates/build/templates/new/_Cargo.toml
+++ b/crates/build/templates/new/_Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 ink = { version = "6.0.0-alpha", default-features = false, features = ["unstable-hostfn"] }
 
 [dev-dependencies]
-ink_e2e = { git = "https://github.com/use-ink/ink", branch = "master" }
+ink_e2e = "6.0.0-alpha"
 
 [lib]
 path = "lib.rs"

--- a/crates/cargo-contract/Cargo.toml
+++ b/crates/cargo-contract/Cargo.toml
@@ -40,8 +40,8 @@ jsonschema = "0.29"
 schemars = "0.8"
 comfy-table = "7.1.1"
 
-ink_metadata = { git = "https://github.com/use-ink/ink", branch = "master", default-features = false, features = ["std", "derive"] }
-ink_env = { git = "https://github.com/use-ink/ink", branch = "master" }
+ink_metadata = {  version = "6.0.0-alpha", default-features = false, features = ["std", "derive"] }
+ink_env = "6.0.0-alpha"
 
 # dependencies for extrinsics (deploying and calling a contract)
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/crates/extrinsics/Cargo.toml
+++ b/crates/extrinsics/Cargo.toml
@@ -42,11 +42,11 @@ sp-weights = { version = "31.1.0", default-features = false }
 pallet-revive = "0.5.0"
 pallet-revive-uapi = { version = "0.4.0", default-features = false, features = ["unstable-hostfn", "scale"] }
 
-ink_metadata = { git = "https://github.com/use-ink/ink", branch = "master", default-features = false, features = ["std", "derive"] }
-ink_env = { git = "https://github.com/use-ink/ink", branch = "master" }
+ink_metadata = { version = "6.0.0-alpha", default-features = false, features = ["std", "derive"] }
+ink_env = "6.0.0-alpha"
 
 [dev-dependencies]
-ink = { git = "https://github.com/use-ink/ink", branch = "master" }
+ink = "6.0.0-alpha"
 assert_cmd = "2.0.17"
 regex = "1.11.1"
 predicates = "3.1.3"

--- a/crates/transcode/Cargo.toml
+++ b/crates/transcode/Cargo.toml
@@ -24,8 +24,8 @@ contract-metadata = { version = "6.0.0-alpha", path = "../metadata" }
 escape8259 = "0.5.2"
 hex = "0.4.3"
 indexmap = "2.7.1"
-ink_env = { git = "https://github.com/use-ink/ink", branch = "master" }
-ink_metadata = { git = "https://github.com/use-ink/ink", branch = "master", default-features = false, features = ["std", "derive"] }
+ink_env = "6.0.0-alpha"
+ink_metadata = { version = "6.0.0-alpha", default-features = false, features = ["std", "derive"] }
 itertools = "0.14.0"
 tracing = "0.1.40"
 nom = "7.1.3"
@@ -41,7 +41,7 @@ regex = "1.11.1"
 
 [dev-dependencies]
 assert_matches = "1.5.0"
-ink = { git = "https://github.com/use-ink/ink", branch = "master", features = ["unstable-hostfn"] }
+ink = { version = "6.0.0-alpha", features = ["unstable-hostfn"] }
 sp-core = { version = "36.1.0", default-features = false }
 sp-keyring = { version = "41.0.0", default-features = false }
 


### PR DESCRIPTION
Update ink! dependencies to target the` v6.0.0-alpha` release.

Test are failing because this line: https://github.com/use-ink/cargo-contract/pull/2026/files#diff-955d62dc3113f168fa64fe7ba020dc0a0837d43fed594fa73fbccbb5b72f4a0cL11
`ink_e2e = "6.0.0-alpha"`

The crate `ink_e2e` will be released after cargo-contract is published because `ink_e2e` is dependent on the `cargo-contract` crates.  https://github.com/use-ink/ink/blob/master/RELEASES_CHECKLIST.md?plain=1#L57

So the steps will be:
- First I am going to release `cargo-contracts`.
- Update the dependency https://github.com/use-ink/ink/blob/master/Cargo.toml#L41 in https://github.com/use-ink/ink/pull/2498
-  Release `ink_e2e`