### PR TITLE
fix: erroneous "[lib] name" warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [Unreleased]
 
+### Fixed
+- Fixed erroneous "[lib] name" warnings - [#2035](https://github.com/use-ink/cargo-contract/pull/2035)
+
 ## [6.0.0-alpha]
 
 This is our first alpha release for `cargo-contract` v6. We release it together

--- a/crates/build/src/crate_metadata.rs
+++ b/crates/build/src/crate_metadata.rs
@@ -81,8 +81,8 @@ impl CrateMetadata {
             // Warn user if they still specify a lib name different from the
             // package name.
             // NOTE: If no lib name is specified, cargo "normalizes" the package name
-            // and auto inserts it as the lib name. So we need to normalize the package name
-            // before making the comparison.
+            // and auto inserts it as the lib name. So we need to normalize the package
+            // name before making the comparison.
             // Ref: <https://github.com/rust-lang/cargo/blob/3c5bb555caf3fad02927fcfd790ee525da17ce5a/src/cargo/util/toml/targets.rs#L177-L178>
             let expected_lib_name = root_package.name.replace("-", "_");
             if lib_name.name != expected_lib_name {

--- a/crates/build/src/crate_metadata.rs
+++ b/crates/build/src/crate_metadata.rs
@@ -78,9 +78,14 @@ impl CrateMetadata {
             .iter()
             .find(|target| target.kind.contains(&TargetKind::Lib))
         {
-            if lib_name.name != root_package.name {
-                // warn user if they still specify a lib name different from the
-                // package name
+            // Warn user if they still specify a lib name different from the
+            // package name.
+            // NOTE: If no lib name is specified, cargo "normalizes" the package name
+            // and auto inserts it as the lib name. So we need to normalize the package name
+            // before making the comparison.
+            // Ref: <https://github.com/rust-lang/cargo/blob/3c5bb555caf3fad02927fcfd790ee525da17ce5a/src/cargo/util/toml/targets.rs#L177-L178>
+            let expected_lib_name = root_package.name.replace("-", "_");
+            if lib_name.name != expected_lib_name {
                 use colored::Colorize;
                 eprintln!(
                     "{} the `name` field in the `[lib]` section of the `Cargo.toml`, \


### PR DESCRIPTION
## Summary
Closes #_
- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependent on the specific version of `ink` or `pallet-contracts`?
<!--- Provide a general summary of your changes -->

## Description
<!--- Describe your changes in detail -->

`cargo-contract` erroneously emits the warning below about "[lib] name" in `Cargo.toml` for all contracts that include a hyphen in the package name, even when no name is specified in the `[lib]` section.

<img width="796" alt="Screenshot 2025-05-11 at 17 17 26" src="https://github.com/user-attachments/assets/7d019afb-9df6-486a-8ac8-211a00a7ef8c" />

This is because if no "[lib] name" is specified, cargo "normalizes" the package name and auto inserts it as the lib name. The code that emits this warning currently doesn't take this into consideration (especially the "normalization" part) and hence emits this warning erroneously for hyphenated package names.

This PR fixes the this behavior by comparing the "[lib] name" retrieved from `cargo metadata` to the normalized package name before emitting the warning.

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have added an entry to `CHANGELOG.md`
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
