### PR TITLE
Add `--nocapture` flag to `cargo contract test` subcommand

### DIFF
--- a/crates/cargo-contract/src/cmd/test_cmd.rs
+++ b/crates/cargo-contract/src/cmd/test_cmd.rs
@@ -38,6 +38,9 @@ pub struct TestCommand {
     all_features: bool,
     #[clap(flatten)]
     verbosity: VerbosityFlags,
+    /// Disable capturing of test output (e.g. for debugging).
+    #[clap(long)]
+    nocapture: bool,
     /// Arguments to pass to `cargo test`.
     #[arg(last = true)]
     args: Vec<String>,
@@ -54,6 +57,13 @@ impl TestCommand {
         }
         if !self.args.is_empty() {
             args.extend(self.args.clone());
+        }
+        if self.nocapture {
+            // Adds escape arg (if necessary).
+            if !self.args.iter().any(|arg| arg == "--") {
+                args.push("--".to_string());
+            }
+            args.push("--nocapture".to_string());
         }
 
         // Composes ABI `cfg` flag.


### PR DESCRIPTION
## Summary
Follow up to https://github.com/use-ink/cargo-contract/pull/2034
- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependent on the specific version of `ink` or `pallet-contracts`?
<!--- Provide a general summary of your changes -->

## Description
<!--- Describe your changes in detail -->

[Current ink! docs](https://use.ink/docs/v5/ink-vs-solidity/#unit-testing-off-chain) recommend using the `--nocapture` flag with `cargo test` show debug output for tests, which requires argument escaping (i.e. `cargo test -- --nocapture`). 
With the new `cargo contract test` subcommand ([see here](https://github.com/use-ink/cargo-contract/pull/2034)), this now requires double escaping (i.e. `cargo contract test -- -- --nocapture`).

This PR adds the `--nocapture` flag to the `cargo contract test` to simply this presumably common action (i.e. `cargo contract test --nocapture`)

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [ ] I have added an entry to `CHANGELOG.md`
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
