### PR TITLE
Mark `rustc` wrapper crate as a non-member of any workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support setting ABI in `Cargo.toml` and propagate ABI into build environment via `cfg` flag - [#2033](https://github.com/use-ink/cargo-contract/pull/2033)
 - Add `cargo contract test` subcommand - [#2034](https://github.com/use-ink/cargo-contract/pull/2034)
 - Add `--nocapture` flag to `cargo contract test` subcommand - [#2037](https://github.com/use-ink/cargo-contract/pull/2037)
+- Mark `rustc` wrapper crate as a non-member of any workspace - [#2038](https://github.com/use-ink/cargo-contract/pull/2038)
 
 ### Fixed
 - Fixed erroneous "[lib] name" warnings - [#2035](https://github.com/use-ink/cargo-contract/pull/2035)

--- a/crates/build/templates/rustc_wrapper/_Cargo.toml
+++ b/crates/build/templates/rustc_wrapper/_Cargo.toml
@@ -10,3 +10,6 @@ name = "rustc_wrapper"
 path = "main.rs"
 
 [dependencies]
+
+[workspace]
+# Tells cargo that this crate is not part of the workspace.


### PR DESCRIPTION
## Summary

Follow up to https://github.com/use-ink/cargo-contract/pull/2033

- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependent on the specific version of `ink` or `pallet-contracts`?
<!--- Provide a general summary of your changes -->

## Description
<!--- Describe your changes in detail -->

In ink!'s CI, the `rustc` wrapper crate can end up in a directory structure where `cargo` "believes" it's a workspace member, causing its compilation to fail.

This PR explicitly marks the `rustc` wrapper crate as a non-member of any workspace by adding an empty `[workspace]` table to its manifest.

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have added an entry to `CHANGELOG.md`
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
