### PR TITLE
refactor: Reusable `rustc` wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Bump the version of `subxt` and `subxt-signer` - [#2036](https://github.com/use-ink/cargo-contract/pull/2036)
+- Reusable `rustc` wrapper - [#2039](https://github.com/use-ink/cargo-contract/pull/2039)
 
 ## [6.0.0-alpha]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9381,13 +9381,12 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "2.6.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dcb24d0152526ae49b9b96c1dcf71850ca1e0b882e4e28ed898a93c41334744"
+checksum = "12598812502ed0105f607f941c386f43d441e00148fce9dec3ca5ffb0bde9308"
 dependencies = [
  "arbitrary",
  "crc32fast",
- "crossbeam-utils",
  "indexmap 2.9.0",
  "memchr",
 ]

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -38,7 +38,7 @@ tempfile = "3.16.0"
 term_size = "0.3.2"
 url = { version = "2.5.4", features = ["serde"] }
 which = "7.0.1"
-zip = { version = "2.2.2", default-features = false }
+zip = { version = "3.0.0", default-features = false }
 tokio = { version = "1.44.2", features = ["macros", "rt-multi-thread"] }
 tokio-stream = "0.1.17"
 bollard = "0.18.1"
@@ -58,7 +58,7 @@ uzers = "0.12"
 [build-dependencies]
 anyhow = "1.0.95"
 walkdir = "2.5.0"
-zip = { version = "2.2.2", default-features = false }
+zip = { version = "3.0.0", default-features = false }
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"

--- a/crates/build/src/crate_metadata.rs
+++ b/crates/build/src/crate_metadata.rs
@@ -76,7 +76,7 @@ impl CrateMetadata {
         let contract_artifact_name = root_package.name.replace('-', "_");
 
         // Retrieves ABI from package metadata (if specified).
-        let abi = get_package_abi(&root_package).transpose()?;
+        let abi = package_abi(&root_package).transpose()?;
 
         if let Some(lib_name) = &root_package
             .targets
@@ -255,12 +255,8 @@ fn get_cargo_toml_metadata(manifest_path: &ManifestPath) -> Result<ExtraMetadata
 
 /// Returns ABI specified (if any) for the package (i.e. via
 /// `package.metadata.ink-lang.abi`).
-fn get_package_abi(root_package: &Package) -> Option<Result<Abi>> {
-    let abi_str = root_package
-        .metadata
-        .get("ink-lang")?
-        .get("abi")?
-        .as_str()?;
+pub fn package_abi(package: &Package) -> Option<Result<Abi>> {
+    let abi_str = package.metadata.get("ink-lang")?.get("abi")?.as_str()?;
     let abi = match abi_str {
         "ink" => Abi::Ink,
         "sol" => Abi::Solidity,
@@ -277,7 +273,7 @@ mod tests {
 
     use super::{
         get_cargo_metadata,
-        get_package_abi,
+        package_abi,
     };
     use crate::{
         new_contract_project,
@@ -298,7 +294,7 @@ mod tests {
 
                 let manifest_path = ManifestPath::new(dir.join("Cargo.toml")).unwrap();
                 let (_, root_package) = get_cargo_metadata(&manifest_path).unwrap();
-                let parsed_abi = get_package_abi(&root_package)
+                let parsed_abi = package_abi(&root_package)
                     .expect("Expected an ABI declaration")
                     .expect("Expected a valid ABI");
                 assert_eq!(parsed_abi, abi);
@@ -323,7 +319,7 @@ mod tests {
 
             let manifest_path = ManifestPath::new(dir.join("Cargo.toml")).unwrap();
             let (_, root_package) = get_cargo_metadata(&manifest_path).unwrap();
-            let parsed_abi = get_package_abi(&root_package);
+            let parsed_abi = package_abi(&root_package);
             assert!(parsed_abi.is_none(), "Should be None");
 
             Ok(())
@@ -348,7 +344,7 @@ mod tests {
             let manifest_path = ManifestPath::new(cargo_toml).unwrap();
             let (_, root_package) = get_cargo_metadata(&manifest_path).unwrap();
             let parsed_abi =
-                get_package_abi(&root_package).expect("Expected an ABI declaration");
+                package_abi(&root_package).expect("Expected an ABI declaration");
             assert!(parsed_abi.is_err(), "Should be Err");
             assert!(parsed_abi.unwrap_err().to_string().contains("Unknown ABI"));
 

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -30,7 +30,6 @@ mod docker;
 mod lint;
 pub mod metadata;
 mod new;
-mod rustc_wrapper;
 mod solidity_metadata;
 #[cfg(test)]
 mod tests;
@@ -379,11 +378,13 @@ fn exec_cargo_for_onchain_target(
             let abi_cfg_flags = abi.cargo_encoded_rustflag();
             rustflags.push_str(&abi_cfg_flags);
 
-            // Sets a custom `RUSTC_WRAPPER` which passes compiler flags to `rustc`,
+            // Sets a custom `rustc` wrapper which passes compiler flags to `rustc`,
             // because `cargo` doesn't pass compiler flags to proc macros and build
             // scripts when the `--target` flag is set.
-            // See `rustc_wrapper::env_vars` docs for details.
-            if let Some(rustc_wrapper_envs) = rustc_wrapper::env_vars(crate_metadata)? {
+            // See `util::rustc_wrapper::env_vars` docs for details.
+            if let Some(rustc_wrapper_envs) =
+                util::rustc_wrapper::env_vars(crate_metadata)?
+            {
                 env.extend(rustc_wrapper_envs);
             }
         }

--- a/crates/build/src/lib.rs
+++ b/crates/build/src/lib.rs
@@ -54,7 +54,10 @@ pub use self::{
         Verbosity,
         VerbosityFlags,
     },
-    crate_metadata::CrateMetadata,
+    crate_metadata::{
+        package_abi,
+        CrateMetadata,
+    },
     metadata::{
         BuildInfo,
         InkMetadataArtifacts,

--- a/crates/build/src/lint.rs
+++ b/crates/build/src/lint.rs
@@ -14,21 +14,21 @@
 // You should have received a copy of the GNU General Public License
 // along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
 
-use crate::{
-    execute_cargo,
-    onchain_cargo_options,
-    rustc_wrapper,
-    util,
-    verbose_eprintln,
-    CrateMetadata,
-    Verbosity,
-    Workspace,
-};
 use anyhow::Result;
 use colored::Colorize;
 use std::{
     path::Path,
     process::Command,
+};
+
+use crate::{
+    execute_cargo,
+    onchain_cargo_options,
+    util,
+    verbose_eprintln,
+    CrateMetadata,
+    Verbosity,
+    Workspace,
 };
 
 /// Toolchain used to build ink_linting:
@@ -119,11 +119,11 @@ fn exec_cargo_dylint(
         rustflags.push(' ');
         rustflags.push_str(&abi.rustflag());
 
-        // Sets a custom `RUSTC_WRAPPER` which passes compiler flags to `rustc`,
+        // Sets a custom `rustc` wrapper which passes compiler flags to `rustc`,
         // because `cargo` doesn't pass compiler flags to proc macros and build
         // scripts when the `--target` flag is set.
-        // See `rustc_wrapper::env_vars` docs for details.
-        if let Some(rustc_wrapper_envs) = rustc_wrapper::env_vars(crate_metadata)? {
+        // See `util::rustc_wrapper::env_vars` docs for details.
+        if let Some(rustc_wrapper_envs) = util::rustc_wrapper::env_vars(crate_metadata)? {
             env.extend(rustc_wrapper_envs);
         }
     }

--- a/crates/build/src/util/mod.rs
+++ b/crates/build/src/util/mod.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
 
+pub mod rustc_wrapper;
 #[cfg(test)]
 pub mod tests;
 

--- a/crates/build/src/util/rustc_wrapper.rs
+++ b/crates/build/src/util/rustc_wrapper.rs
@@ -55,8 +55,8 @@ pub(crate) fn generate<P: AsRef<Path>>(target_dir: P) -> Result<String> {
     tracing::debug!("Generating `rustc` wrapper executable in {}", dir.display());
 
     // Creates `rustc` wrapper project.
-    let cargo_toml = include_str!("../templates/rustc_wrapper/_Cargo.toml");
-    let main_rs = include_str!("../templates/rustc_wrapper/main.rs");
+    let cargo_toml = include_str!("../../templates/rustc_wrapper/_Cargo.toml");
+    let main_rs = include_str!("../../templates/rustc_wrapper/main.rs");
     let manifest_path = dir.join("Cargo.toml");
     fs::write(&manifest_path, cargo_toml)?;
     fs::write(dir.join("main.rs"), main_rs)?;
@@ -98,7 +98,8 @@ pub(crate) fn generate<P: AsRef<Path>>(target_dir: P) -> Result<String> {
     exec_path_str.context("Failed to generate `rustc` wrapper")
 }
 
-/// Returns a list env vars required to set a custom `rustc` wrapper (if necessary).
+/// Returns a list env vars required to set a custom `rustc` wrapper and ABI `cfg` flags
+/// (if necessary).
 ///
 /// # Note
 ///

--- a/crates/build/src/util/rustc_wrapper.rs
+++ b/crates/build/src/util/rustc_wrapper.rs
@@ -50,7 +50,7 @@ use crate::{
 /// Generates a `rustc` wrapper executable and returns its path.
 ///
 /// See [`crate::rustc_wrapper`] module docs for motivation.
-pub(crate) fn generate<P: AsRef<Path>>(target_dir: P) -> Result<String> {
+pub fn generate<P: AsRef<Path>>(target_dir: P) -> Result<String> {
     let dir = target_dir.as_ref().join("rustc_wrapper");
     fs::create_dir_all(&dir)?;
     tracing::debug!("Generating `rustc` wrapper executable in {}", dir.display());
@@ -110,7 +110,7 @@ pub(crate) fn generate<P: AsRef<Path>>(target_dir: P) -> Result<String> {
 ///
 /// The extra compiler flags to pass are specified via the `RUSTC_WRAPPER_ENCODED_FLAGS`
 /// env var.
-pub(crate) fn env_vars(crate_metadata: &CrateMetadata) -> Result<Option<EnvVars>> {
+pub fn env_vars(crate_metadata: &CrateMetadata) -> Result<Option<EnvVars>> {
     if let Some(abi) = crate_metadata.abi {
         let rustc_wrapper = env::var("INK_RUSTC_WRAPPER")
             .context("Failed to retrieve `rustc` wrapper from environment")


### PR DESCRIPTION
## Summary
Follow up to https://github.com/use-ink/cargo-contract/pull/2033

- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependent on the specific version of `ink` or `pallet-contracts`?
<!--- Provide a general summary of your changes -->

## Description
<!--- Describe your changes in detail -->

- Makes `rustc` wrapper reusable across a build via an env var
- Exposes `rustc` wrapper and ABI parsing utilities in public interface

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have added an entry to `CHANGELOG.md`
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
