### PR TITLE
feat(cargo-contract): display fee estimation on map account dry-run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Support setting ABI in `Cargo.toml` and propagate ABI into build environment via `cfg` flag - [#2033](https://github.com/use-ink/cargo-contract/pull/2033)
 - Add `cargo contract test` subcommand - [#2034](https://github.com/use-ink/cargo-contract/pull/2034)
+- Show cost of mapping an address in `cargo-contract` prompt - [#1990](https://github.com/use-ink/cargo-contract/issues/1990)
 
 ### Fixed
 - Fixed erroneous "[lib] name" warnings - [#2035](https://github.com/use-ink/cargo-contract/pull/2035)

--- a/crates/cargo-contract/src/cmd/mod.rs
+++ b/crates/cargo-contract/src/cmd/mod.rs
@@ -300,9 +300,13 @@ where
     let map_exec: MapAccountExec<C, C, _> =
         MapAccountCommandBuilder::new(extrinsic_opts).done().await?;
     let result = map_exec.map_account_dry_run().await;
-    if result.is_ok() {
+    if let Ok(partial_fee_estimation) = result {
         let reply = prompt_confirm_mapping(|| {
-            // todo print additional information about the costs of mapping an account
+            name_value_println!(
+                "Estimated fee",
+                format!("{:?}", partial_fee_estimation),
+                DEFAULT_KEY_COL_WIDTH
+            );
         });
         if reply.is_ok() {
             let res = map_exec.map_account().await?;

--- a/crates/extrinsics/src/lib.rs
+++ b/crates/extrinsics/src/lib.rs
@@ -221,7 +221,8 @@ where
     Err(RpcError::SubscriptionDropped.into())
 }
 
-/// Wait for the transaction to be included successfully into a block.
+/// Wait for the transaction to be included successfully into a block. Returns the
+/// estimated fee to execute the transaction.
 ///
 /// # Errors
 ///

--- a/crates/extrinsics/src/lib.rs
+++ b/crates/extrinsics/src/lib.rs
@@ -238,7 +238,7 @@ async fn dry_run_extrinsic<C, Call, Signer>(
     rpc: &LegacyRpcMethods<C>,
     call: &Call,
     signer: &Signer,
-) -> core::result::Result<DryRunResultBytes, subxt::Error>
+) -> core::result::Result<(DryRunResultBytes, u128), subxt::Error>
 where
     C: Config,
     Call: tx::Payload,
@@ -256,7 +256,9 @@ where
         .tx()
         .create_partial_offline(call, params.into())?
         .sign(signer);
-    Ok(rpc.dry_run(extrinsic.encoded(), None).await?)
+    let result = rpc.dry_run(extrinsic.encoded(), None).await?;
+    let partial_fee_estimate = extrinsic.partial_fee_estimate().await?;
+    Ok((result, partial_fee_estimate))
 }
 
 /// Return the account nonce at the *best* block for an account ID.

--- a/crates/extrinsics/src/map_account.rs
+++ b/crates/extrinsics/src/map_account.rs
@@ -143,20 +143,20 @@ where
     /// instantiation on the blockchain.
     ///
     /// Returns the dry run simulation result, or an error in case of failure.
-    pub async fn map_account_dry_run(&self) -> Result<()> {
+    pub async fn map_account_dry_run(&self) -> Result<u128> {
         let call = MapAccount::new().build();
-        let bytes =
+        let (bytes, partial_fee_estimation) =
             dry_run_extrinsic(&self.client, &self.rpc, &call, self.opts.signer()).await?;
         let res = bytes.into_dry_run_result();
         match res {
-            Ok(DryRunResult::Success) => Ok(()),
+            Ok(DryRunResult::Success) => Ok(partial_fee_estimation),
             Ok(DryRunResult::DispatchError(err)) => {
                 Err(anyhow::format_err!("dispatch error: {:?}", err))
             }
             Ok(DryRunResult::TransactionValidityError) => {
                 // todo seems like an external bug: https://github.com/paritytech/polkadot-sdk/issues/7305
                 // Err(anyhow::format_err!("validity err"))
-                Ok(())
+                Ok(partial_fee_estimation)
             }
             Err(err) => {
                 match err {


### PR DESCRIPTION
## Summary
Closes #_
- [ ] y/n | Does it introduce breaking changes?
- [ ] y/n | Is it dependent on the specific version of `ink` or `pallet-contracts`?
<!--- Provide a general summary of your changes -->

## Description
<!--- Describe your changes in detail -->

Linked to the issue: https://github.com/use-ink/cargo-contract/issues/1990

This PR updates the `map_account_dry_run` method to return the `partial_fee_estimation` before the user confirm wether to map the account or not. 

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have added an entry to `CHANGELOG.md`
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
