### PR TITLE
Update Solidity metadata generation to support `SolEncode` and `SolDecode` implementing arbitrary types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1624,7 +1624,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1633,7 +1633,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1796,7 +1796,6 @@ dependencies = [
  "pretty_assertions",
  "regex",
  "rustc_version 0.4.1",
- "scale-info",
  "semver 1.0.26",
  "serde",
  "serde_json",
@@ -2524,7 +2523,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3660,7 +3659,7 @@ dependencies = [
 [[package]]
 name = "ink"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#c61ff0e90efaf55a1b91a2e77f2d87dc46275af7"
+source = "git+https://github.com/use-ink/ink?branch=master#641342d43d93d106f6e44e0d369c5398c672f12b"
 dependencies = [
  "const_format",
  "deranged",
@@ -3685,7 +3684,7 @@ dependencies = [
 [[package]]
 name = "ink_allocator"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#c61ff0e90efaf55a1b91a2e77f2d87dc46275af7"
+source = "git+https://github.com/use-ink/ink?branch=master#641342d43d93d106f6e44e0d369c5398c672f12b"
 dependencies = [
  "cfg-if",
 ]
@@ -3693,7 +3692,7 @@ dependencies = [
 [[package]]
 name = "ink_codegen"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#c61ff0e90efaf55a1b91a2e77f2d87dc46275af7"
+source = "git+https://github.com/use-ink/ink?branch=master#641342d43d93d106f6e44e0d369c5398c672f12b"
 dependencies = [
  "blake2",
  "derive_more 2.0.1",
@@ -3715,7 +3714,7 @@ dependencies = [
 [[package]]
 name = "ink_engine"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#c61ff0e90efaf55a1b91a2e77f2d87dc46275af7"
+source = "git+https://github.com/use-ink/ink?branch=master#641342d43d93d106f6e44e0d369c5398c672f12b"
 dependencies = [
  "blake2",
  "derive_more 2.0.1",
@@ -3732,7 +3731,7 @@ dependencies = [
 [[package]]
 name = "ink_env"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#c61ff0e90efaf55a1b91a2e77f2d87dc46275af7"
+source = "git+https://github.com/use-ink/ink?branch=master#641342d43d93d106f6e44e0d369c5398c672f12b"
 dependencies = [
  "blake2",
  "cfg-if",
@@ -3765,7 +3764,7 @@ dependencies = [
 [[package]]
 name = "ink_ir"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#c61ff0e90efaf55a1b91a2e77f2d87dc46275af7"
+source = "git+https://github.com/use-ink/ink?branch=master#641342d43d93d106f6e44e0d369c5398c672f12b"
 dependencies = [
  "blake2",
  "either",
@@ -3781,7 +3780,7 @@ dependencies = [
 [[package]]
 name = "ink_macro"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#c61ff0e90efaf55a1b91a2e77f2d87dc46275af7"
+source = "git+https://github.com/use-ink/ink?branch=master#641342d43d93d106f6e44e0d369c5398c672f12b"
 dependencies = [
  "ink_codegen",
  "ink_ir",
@@ -3796,7 +3795,7 @@ dependencies = [
 [[package]]
 name = "ink_metadata"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#c61ff0e90efaf55a1b91a2e77f2d87dc46275af7"
+source = "git+https://github.com/use-ink/ink?branch=master#641342d43d93d106f6e44e0d369c5398c672f12b"
 dependencies = [
  "derive_more 2.0.1",
  "impl-serde",
@@ -3811,7 +3810,7 @@ dependencies = [
 [[package]]
 name = "ink_prelude"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#c61ff0e90efaf55a1b91a2e77f2d87dc46275af7"
+source = "git+https://github.com/use-ink/ink?branch=master#641342d43d93d106f6e44e0d369c5398c672f12b"
 dependencies = [
  "cfg-if",
 ]
@@ -3819,7 +3818,7 @@ dependencies = [
 [[package]]
 name = "ink_primitives"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#c61ff0e90efaf55a1b91a2e77f2d87dc46275af7"
+source = "git+https://github.com/use-ink/ink?branch=master#641342d43d93d106f6e44e0d369c5398c672f12b"
 dependencies = [
  "alloy-sol-types 1.1.0",
  "cfg-if",
@@ -3846,7 +3845,7 @@ dependencies = [
 [[package]]
 name = "ink_storage"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#c61ff0e90efaf55a1b91a2e77f2d87dc46275af7"
+source = "git+https://github.com/use-ink/ink?branch=master#641342d43d93d106f6e44e0d369c5398c672f12b"
 dependencies = [
  "array-init",
  "cfg-if",
@@ -3864,7 +3863,7 @@ dependencies = [
 [[package]]
 name = "ink_storage_traits"
 version = "6.0.0-alpha"
-source = "git+https://github.com/use-ink/ink?branch=master#c61ff0e90efaf55a1b91a2e77f2d87dc46275af7"
+source = "git+https://github.com/use-ink/ink?branch=master#641342d43d93d106f6e44e0d369c5398c672f12b"
 dependencies = [
  "ink_metadata",
  "ink_prelude",
@@ -5863,7 +5862,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5876,7 +5875,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5930,7 +5929,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7935,7 +7934,7 @@ dependencies = [
  "getrandom 0.3.2",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8799,7 +8798,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,7 @@
 [workspace]
 resolver = "2"
 members = ["crates/*"]
+
+[workspace.dependencies]
+ink_metadata = { git = "https://github.com/use-ink/ink", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["std", "derive"] }
+ink_env = { git = "https://github.com/use-ink/ink", branch = "master", version = "6.0.0-alpha" }

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -49,7 +49,7 @@ alloy-json-abi = "0.8.20"
 polkavm-linker = "0.22.0"
 
 contract-metadata = { version = "6.0.0-alpha", path = "../metadata" }
-ink_metadata = { git = "https://github.com/use-ink/ink", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["std", "derive"] }
+ink_metadata = { workspace = true }
 sha3 = "0.10.8"
 
 [target.'cfg(unix)'.dependencies]

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -28,7 +28,6 @@ rustc_version = "0.4.1"
 scale = { package = "parity-scale-codec", version = "3.6.12", features = [
     "derive",
 ] }
-scale-info = "2.11.6"
 toml = "0.8.19"
 tracing = "0.1.41"
 semver = { version = "1.0.25", features = ["serde"] }

--- a/crates/build/src/solidity_metadata.rs
+++ b/crates/build/src/solidity_metadata.rs
@@ -40,7 +40,6 @@ use contract_metadata::{
     Contract,
     Source,
 };
-use ink_metadata::InkProject;
 use serde::{
     Deserialize,
     Serialize,
@@ -179,7 +178,7 @@ impl SourceFile {
 ///
 /// Ref: <https://docs.soliditylang.org/en/latest/metadata.html>
 pub fn generate_metadata(
-    ink_project: &InkProject,
+    ink_project: &ink_metadata::sol::ContractMetadata,
     abi: JsonAbi,
     source: Source,
     contract: Contract,

--- a/crates/build/src/solidity_metadata.rs
+++ b/crates/build/src/solidity_metadata.rs
@@ -59,7 +59,7 @@ use crate::{
     CrateMetadata,
 };
 
-// Re-exports abi utilities.
+// Re-exports ABI utilities.
 pub use self::abi::{
     abi_path,
     generate_abi,

--- a/crates/build/src/solidity_metadata/abi.rs
+++ b/crates/build/src/solidity_metadata/abi.rs
@@ -15,6 +15,7 @@
 // along with cargo-contract.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::{
+    borrow::Cow,
     collections::BTreeMap,
     fs::{
         self,
@@ -31,72 +32,47 @@ use alloy_json_abi::{
     Function,
     JsonAbi,
 };
-use anyhow::{
-    Context,
-    Result,
-};
-use ink_metadata::{
-    ConstructorSpec,
-    EventSpec,
-    InkProject,
-    MessageParamSpec,
-    MessageSpec,
-    ReturnTypeSpec,
-};
+use anyhow::Result;
 use itertools::Itertools;
-use scale_info::{
-    form::PortableForm,
-    PortableRegistry,
-    TypeDef,
-    TypeDefPrimitive,
-};
 
 use crate::CrateMetadata;
 
 /// Generates a Solidity compatible ABI for the ink! smart contract (if possible).
 ///
 /// Ref: <https://docs.soliditylang.org/en/latest/abi-spec.html#abi-json>
-pub fn generate_abi(ink_project: &InkProject) -> Result<JsonAbi> {
-    let registry = ink_project.registry();
-    let spec = ink_project.spec();
-
+pub fn generate_abi(meta: &ink_metadata::sol::ContractMetadata) -> Result<JsonAbi> {
     // Solidity allows only one constructor, we choose the "default" one (or fallback to
     // the first one).
-    let ctors = spec.constructors();
+    let ctors = &meta.constructors;
     let ctor = ctors
         .iter()
-        .find_or_first(|ctor| ctor.default())
+        .find_or_first(|ctor| ctor.is_default)
         .ok_or_else(|| {
             anyhow::anyhow!("Expected at least one constructor in contract metadata")
         })?;
-    if !ctor.default() && ctors.len() > 1 {
+    if !ctor.is_default && ctors.len() > 1 {
         // Nudge the user to set a default constructor.
         use colored::Colorize;
         eprintln!(
             "{} No default constructor set. \
             \n    A default constructor is necessary to guarantee consistent Solidity compatible \
-            metadata output across different rustc and cargo-contract releases. \
+            metadata output across different `rustc` and `cargo-contract` releases. \
             \n    Learn more at https://use.ink/6.x/macros-attributes/default/",
             "warning:".yellow().bold()
         );
     }
-    let ctor_abi = constructor(ctor, registry)?;
+    let ctor_abi = constructor(ctor)?;
 
-    let fn_abis: BTreeMap<_, _> = spec
-        .messages()
+    let fn_abis: BTreeMap<_, _> = meta
+        .functions
         .iter()
-        .map(|msg| {
-            message(msg, registry).map(|fn_abi| (msg.label().clone(), vec![fn_abi]))
-        })
+        .map(|msg| message(msg).map(|fn_abi| (msg.name.to_string(), vec![fn_abi])))
         .process_results(|iter| iter.collect())?;
 
-    let event_abis: BTreeMap<_, _> = spec
-        .events()
+    let event_abis: BTreeMap<_, _> = meta
+        .events
         .iter()
-        .map(|event_spec| {
-            event(event_spec, registry)
-                .map(|event_abi| (event_spec.label().clone(), vec![event_abi]))
-        })
+        .map(|evt| event(evt).map(|evt_abi| (evt.name.to_string(), vec![evt_abi])))
         .process_results(|iter| iter.collect())?;
 
     Ok(JsonAbi {
@@ -129,276 +105,74 @@ where
 }
 
 /// Returns the constructor ABI representation for an ink! constructor.
-fn constructor(
-    ctor: &ConstructorSpec<PortableForm>,
-    registry: &PortableRegistry,
-) -> Result<Constructor> {
-    let params = ctor
-        .args()
-        .iter()
-        .map(|param| {
-            param_decl(param, registry, &format!("constructor `{}`", ctor.label()))
-        })
-        .process_results(|mut iter| iter.join(","))?;
+fn constructor(ctor: &ink_metadata::sol::ConstructorMetadata) -> Result<Constructor> {
+    let params = ctor.inputs.iter().map(param_decl).join(",");
 
     // NOTE: Solidity constructors don't expose a return type.
     let abi_str = format!(
         "constructor({params}){}",
-        if ctor.payable { " payable" } else { "" }
+        if ctor.is_payable { " payable" } else { "" }
     );
     Constructor::parse(&abi_str).map_err(|err| {
         anyhow::anyhow!(
             "Failed to parse abi for constructor `{}` : {err}",
-            ctor.label()
+            ctor.name
         )
     })
 }
 
 /// Returns the function ABI representation for an ink! message.
-fn message(
-    msg: &MessageSpec<PortableForm>,
-    registry: &PortableRegistry,
-) -> Result<Function> {
-    let name = msg.label();
-    let params = msg
-        .args()
-        .iter()
-        .map(|param| param_decl(param, registry, &format!("message `{}`", name)))
-        .process_results(|mut iter| iter.join(","))?;
-    let ret_ty = return_ty(msg.return_type(), registry, &format!("message `{}`", name))?;
+fn message(msg: &ink_metadata::sol::FunctionMetadata) -> Result<Function> {
+    let name = msg.name.as_ref();
+    let params = msg.inputs.iter().map(param_decl).join(",");
+    let ret_ty = msg.output.as_ref().map(Cow::as_ref);
 
     let abi_str = format!(
         "function {name}({params}) public{}{}{}",
         // FIXME: (@davidsemakula) ink! does NOT currently enforce it's immutability
         // claims for messages intrinsically (i.e at compile time).
         // Ref: <https://github.com/use-ink/ink/issues/1969>
-        if msg.mutates() { "" } else { " view" },
-        if msg.payable() { " payable" } else { "" },
-        if ret_ty.is_empty() || ret_ty == "()" {
-            String::new()
-        } else {
-            format!(" returns ({ret_ty})")
+        if msg.mutates { "" } else { " view" },
+        if msg.is_payable { " payable" } else { "" },
+        match ret_ty {
+            None | Some("()") => String::new(),
+            Some(ret_ty) => format!(" returns ({ret_ty})"),
         },
     );
     Function::parse(&abi_str).map_err(|err| {
-        anyhow::anyhow!("Failed to parse abi for message `{}` : {err}", msg.label())
+        anyhow::anyhow!("Failed to parse abi for message `{}` : {err}", msg.name)
     })
 }
 
 /// Returns the event ABI representation for an ink! event.
-fn event(
-    event_spec: &EventSpec<PortableForm>,
-    registry: &PortableRegistry,
-) -> Result<Event> {
-    let name = event_spec.label();
-    let params = event_spec
-        .args()
+fn event(evt: &ink_metadata::sol::EventMetadata) -> Result<Event> {
+    let name = evt.name.as_ref();
+    let params = evt
+        .params
         .iter()
         .map(|param| {
-            let param_name = param.label();
-            let ty_id = param.ty().ty().id;
-            let sol_ty = resolve_ty(
-                ty_id,
-                registry,
-                &format!("arg `{param_name}` for event `{name}`"),
-            );
-            // TODO: (@davidsemakula) should we simply omit events with Solidity ABI
-            // incompatible types instead of bailing?
-            sol_ty.map(|ty| {
-                format!(
-                    "{ty}{} {param_name}",
-                    if param.indexed() { " indexed" } else { "" }
-                )
-            })
+            let param_name = param.name.as_ref();
+            let ty = param.ty.as_ref();
+            format!(
+                "{ty}{} {param_name}",
+                if param.is_topic { " indexed" } else { "" }
+            )
         })
-        .process_results(|mut iter| iter.join(","))?;
+        .join(",");
 
     let abi_str = format!(
         "event {name}({params}){}",
-        if event_spec.signature_topic().is_none() {
-            " anonymous"
-        } else {
-            ""
-        }
+        if evt.is_anonymous { " anonymous" } else { "" }
     );
     Event::parse(&abi_str).map_err(|err| {
-        anyhow::anyhow!(
-            "Failed to parse abi for event `{}` : {err}",
-            event_spec.label()
-        )
+        anyhow::anyhow!("Failed to parse abi for event `{}` : {err}", evt.name)
     })
 }
 
-/// Returns equivalent Solidity ABI declaration (if any) for an ink! constructor or
+/// Returns equivalent Solidity ABI declaration for an ink! constructor or
 /// message parameter.
-fn param_decl(
-    param: &MessageParamSpec<PortableForm>,
-    registry: &PortableRegistry,
-    msg: &str,
-) -> Result<String> {
-    let name = param.label();
-    let ty_id = param.ty().ty().id;
-    let sol_ty = resolve_ty(ty_id, registry, &format!("arg `{name}` for {}", msg));
-    sol_ty.map(|ty| format!("{ty} {name}"))
-}
-
-/// Returns the "user-defined" return type for an ink! message.
-///
-/// **NOTE:** The return type for ink! messages is `Result<T, ink::LangError>`, however,
-/// the ABI return type we're interested in is the "user-defined" `T` type.
-fn return_ty(
-    ret_ty: &ReturnTypeSpec<PortableForm>,
-    registry: &PortableRegistry,
-    msg: &str,
-) -> Result<String> {
-    let id = ret_ty.ret_type().ty().id;
-    let ty = registry
-        .resolve(id)
-        .unwrap_or_else(|| panic!("Failed to resolve return type `#{}` in {}", id, msg));
-    if let TypeDef::Variant(type_def_variant) = &ty.type_def {
-        let ok_field = type_def_variant.variants.first().and_then(|v| {
-            (v.name == "Ok" && v.fields.len() == 1).then_some(&v.fields[0])
-        });
-        if let Some(field) = ok_field {
-            return resolve_ty(field.ty.id, registry, &format!("return type for {msg}"));
-        }
-    }
-
-    anyhow::bail!(
-        "Expected `Result<T, ink::LangError>` return type for {}",
-        msg
-    )
-}
-
-/// Convenience macro for emitting errors for ink! types that are NOT compatible with any
-/// Solidity ABI type.
-macro_rules! incompatible_ty {
-    ($msg: expr, $ty_def: expr) => {
-        anyhow::bail!("Solidity ABI incompatible type in {}: {:?}", $msg, $ty_def)
-    };
-}
-
-/// Returns the equivalent Solidity ABI type (if any) for an ink! type (represented by the
-/// given id in ink! project metadata).
-///
-/// Ref: <https://docs.soliditylang.org/en/latest/abi-spec.html#mapping-solidity-to-abi-types>
-pub fn resolve_ty(id: u32, registry: &PortableRegistry, msg: &str) -> Result<String> {
-    let ty = registry
-        .resolve(id)
-        .context(format!("Failed to resolve type `#{id}` in {msg}"))?;
-    match &ty.type_def {
-        TypeDef::Composite(_) => {
-            let path_segments: Vec<_> =
-                ty.path.segments.iter().map(String::as_str).collect();
-            let ty = match path_segments.as_slice() {
-                ["ink_primitives", "types", "AccountId"]
-                | ["ink_primitives", "types", "Hash"]
-                | ["primitive_types", "H256"] => "bytes32",
-                ["ink_primitives", "types", "Address"] => "address",
-                ["primitive_types", "H160"] => "bytes20",
-                ["primitive_types", "U256"] => "uint256",
-                // NOTE: `bytes1` sequences and arrays are "normalized" to `bytes` or
-                // `bytes<N>` at wrapping `TypeDef::Sequence` or
-                // `TypeDef::Array` match arm (if appropriate).
-                ["ink_primitives", "types", "Byte"] => "bytes1",
-                _ => incompatible_ty!(msg, ty),
-            };
-            Ok(ty.to_string())
-        }
-        TypeDef::Variant(type_def_variant) => {
-            // Unit-only enums (i.e. enums that contain only unit variants) are
-            // represented as uint8.
-            // Ref: <https://docs.soliditylang.org/en/latest/abi-spec.html#mapping-solidity-to-abi-types>
-            // NOTE: This actually checks if an enum is field-less, however, field-less
-            // and unit-only enums have an identical representation in ink! metadata.
-            // Ref: <https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.fieldless>
-            // Ref: <https://doc.rust-lang.org/reference/items/enumerations.html#r-items.enum.unit-only>
-            let contains_fields = type_def_variant
-                .variants
-                .iter()
-                .any(|variant| !variant.fields.is_empty());
-            if !contains_fields {
-                Ok("uint8".to_string())
-            } else {
-                incompatible_ty!(msg, ty)
-            }
-        }
-        TypeDef::Sequence(type_def_seq) => {
-            let elem_ty_id = type_def_seq.type_param.id;
-            let elem_ty = resolve_ty(elem_ty_id, registry, msg)?;
-            let normalized_ty = if elem_ty == "bytes1" {
-                // Normalize `bytes1[]` to `bytes`.
-                // Ref: <https://docs.soliditylang.org/en/latest/types.html#bytes-and-string-as-arrays>
-                "bytes".to_string()
-            } else {
-                format!("{elem_ty}[]")
-            };
-            Ok(normalized_ty)
-        }
-        TypeDef::Array(type_def_array) => {
-            let elem_ty_id = type_def_array.type_param.id;
-            let elem_ty = resolve_ty(elem_ty_id, registry, msg)?;
-            let len = type_def_array.len;
-            let normalized_ty = if elem_ty == "bytes1" && (1..=32).contains(&len) {
-                // Normalize `bytes1[N]` to `bytes<N>` for `1 <= N <= 32`.
-                // Ref: <https://docs.soliditylang.org/en/latest/types.html#fixed-size-byte-arrays>
-                format!("bytes{len}")
-            } else {
-                format!("{elem_ty}[{len}]")
-            };
-            Ok(normalized_ty)
-        }
-        TypeDef::Tuple(type_def_tuple) => {
-            let tys = type_def_tuple
-                .fields
-                .iter()
-                .map(|field| resolve_ty(field.id, registry, msg))
-                .process_results(|mut iter| iter.join(","))?;
-            Ok(format!("({tys})"))
-        }
-        TypeDef::Primitive(type_def_primitive) => {
-            primitive_ty(type_def_primitive, msg).map(ToString::to_string)
-        }
-        TypeDef::Compact(_) | TypeDef::BitSequence(_) => {
-            incompatible_ty!(msg, ty)
-        }
-    }
-}
-
-/// Returns the equivalent Solidity elementary type (if any) for an ink! primitive type
-/// (represented by the given id in ink! project metadata).
-///
-/// Ref: <https://docs.soliditylang.org/en/latest/abi-spec.html#mapping-solidity-to-abi-types>
-fn primitive_ty(ty_def: &TypeDefPrimitive, msg: &str) -> Result<&'static str> {
-    let sol_ty = match ty_def {
-        TypeDefPrimitive::Bool => "bool",
-        // TODO: (@davidsemakula) can we represent char as a `bytes4` fixed-size
-        // array and interpret it in overlong encoding?
-        // Ref: <https://en.wikipedia.org/wiki/UTF-8#overlong_encodings>
-        TypeDefPrimitive::Char => {
-            incompatible_ty!(msg, ty_def);
-        }
-        // NOTE: Rust strings are UTF-8, while solidity string literals
-        // only support ASCII characters, but Solidity also has unicode literals.
-        // However, the Solidity ABI spec uses `string` for both, and claims that `string`
-        // is a "dynamic sized unicode string assumed to be UTF-8 encoded", so presumably
-        // this is fine.
-        // Ref: <https://docs.soliditylang.org/en/latest/abi-spec.html#types>
-        // Ref: <https://docs.soliditylang.org/en/latest/types.html#string-literals-and-types>
-        // Ref: <https://docs.soliditylang.org/en/latest/types.html#unicode-literals>
-        TypeDefPrimitive::Str => "string",
-        TypeDefPrimitive::U8 => "uint8",
-        TypeDefPrimitive::U16 => "uint16",
-        TypeDefPrimitive::U32 => "uint32",
-        TypeDefPrimitive::U64 => "uint64",
-        TypeDefPrimitive::U128 => "uint128",
-        TypeDefPrimitive::U256 => "uint256",
-        TypeDefPrimitive::I8 => "int8",
-        TypeDefPrimitive::I16 => "int16",
-        TypeDefPrimitive::I32 => "int32",
-        TypeDefPrimitive::I64 => "int64",
-        TypeDefPrimitive::I128 => "int128",
-        TypeDefPrimitive::I256 => "int256",
-    };
-    Ok(sol_ty)
+fn param_decl(param: &ink_metadata::sol::ParamMetadata) -> String {
+    let name = param.name.as_ref();
+    let ty = param.ty.as_ref();
+    format!("{ty} {name}")
 }

--- a/crates/build/templates/generate-metadata/main.rs
+++ b/crates/build/templates/generate-metadata/main.rs
@@ -1,13 +1,37 @@
 extern crate contract;
 
+use serde::{Deserialize, Serialize};
+
 extern "Rust" {
-    // Note: The ink! metadata codegen generates an implementation for this function,
+    // Note: The ink! metadata codegen generates an implementation for these functions,
     // which is what we end up linking to here.
     fn __ink_generate_metadata() -> ink::metadata::InkProject;
+    fn __ink_generate_solidity_metadata() -> ink::metadata::sol::ContractMetadata;
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Metadata {
+    ink: Option<ink::metadata::InkProject>,
+    solidity: Option<ink::metadata::sol::ContractMetadata>,
 }
 
 fn main() -> Result<(), std::io::Error> {
-    let metadata = unsafe { __ink_generate_metadata() };
+    // Generate ink! metadata if ABI is NOT "sol".
+    let ink_meta = if cfg!(not(ink_abi = "sol")) {
+        Some(unsafe { __ink_generate_metadata() })
+    } else {
+        None
+    };
+    // Generate Solidity ABI compatibility metadata if ABI is "sol" or "all".
+    let sol_meta = if cfg!(any(ink_abi = "sol", ink_abi = "all")) {
+        Some(unsafe { __ink_generate_solidity_metadata() })
+    } else {
+        None
+    };
+    let metadata = Metadata {
+        ink: ink_meta,
+        solidity: sol_meta,
+    };
     let contents = serde_json::to_string_pretty(&metadata)?;
     print!("{contents}");
     Ok(())

--- a/crates/cargo-contract/Cargo.toml
+++ b/crates/cargo-contract/Cargo.toml
@@ -41,8 +41,8 @@ schemars = "0.8"
 comfy-table = "7.1.1"
 num-traits = "0.2.19"
 
-ink_metadata = { git = "https://github.com/use-ink/ink", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["std", "derive"] }
-ink_env = { git = "https://github.com/use-ink/ink", branch = "master", version = "6.0.0-alpha" }
+ink_metadata = { workspace = true }
+ink_env = { workspace = true }
 
 # dependencies for extrinsics (deploying and calling a contract)
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/crates/extrinsics/Cargo.toml
+++ b/crates/extrinsics/Cargo.toml
@@ -42,8 +42,8 @@ sp-weights = { version = "31.1.0", default-features = false }
 pallet-revive = "0.5.0"
 pallet-revive-uapi = { version = "0.4.0", default-features = false, features = ["unstable-hostfn", "scale"] }
 
-ink_metadata = { git = "https://github.com/use-ink/ink", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["std", "derive"] }
-ink_env = { git = "https://github.com/use-ink/ink", branch = "master", version = "6.0.0-alpha" }
+ink_metadata = { workspace = true }
+ink_env = { workspace = true }
 
 [dev-dependencies]
 ink = { git = "https://github.com/use-ink/ink", branch = "master", version = "6.0.0-alpha" }

--- a/crates/transcode/Cargo.toml
+++ b/crates/transcode/Cargo.toml
@@ -24,8 +24,8 @@ contract-metadata = { version = "6.0.0-alpha", path = "../metadata" }
 escape8259 = "0.5.2"
 hex = "0.4.3"
 indexmap = "2.7.1"
-ink_env = { git = "https://github.com/use-ink/ink", branch = "master", version = "6.0.0-alpha" }
-ink_metadata = { git = "https://github.com/use-ink/ink", branch = "master", version = "6.0.0-alpha", default-features = false, features = ["std", "derive"] }
+ink_env = { workspace = true }
+ink_metadata = { workspace = true }
 itertools = "0.14.0"
 tracing = "0.1.40"
 nom = "7.1.3"


### PR DESCRIPTION
## Summary
Part 2/2 for closing https://github.com/use-ink/cargo-contract/issues/1996 (see https://github.com/use-ink/ink/pull/2510 for part 1/2)

- [n] y/n | Does it introduce breaking changes?
- [y] y/n | Is it dependent on the specific version of `ink` or `pallet-contracts`?
<!--- Provide a general summary of your changes -->

## Description
<!--- Describe your changes in detail -->

Updates Solidity metadata generation to use Solidity specific metadata generated by the ink code generator (see https://github.com/use-ink/ink/pull/2510 for details).
The equivalent Solidity ABI types for constructor, message and event argument types, and message return types are now determined from implementations of the [`SolDecode` and `SolEncode` traits](https://github.com/use-ink/ink/pull/2441) for the respective Rust/ink! types.

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [ ] I have added an entry to `CHANGELOG.md`
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
