### PR TITLE
Declare `ink_abi` as an expected `cfg` in new project `Cargo.toml` template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Validate metadata spec arg against specified ABI for contract build - [#2043](https://github.com/use-ink/cargo-contract/pull/2043)
 - Make metadata spec arg optional for contract build - [#2047](https://github.com/use-ink/cargo-contract/pull/2047)
 - Update Solidity metadata generation to support `SolEncode` and `SolDecode` implementing arbitrary types - [#2048](https://github.com/use-ink/cargo-contract/pull/2048)
+- Declare `ink_abi` as an expected `cfg` in new project `Cargo.toml` template - [#2058](https://github.com/use-ink/cargo-contract/pull/2058)
 
 ## [6.0.0-alpha]
 

--- a/crates/build/templates/new/_Cargo.toml
+++ b/crates/build/templates/new/_Cargo.toml
@@ -20,3 +20,9 @@ std = [
 ]
 ink-as-dependency = []
 e2e-tests = []
+
+[lints.rust.unexpected_cfgs]
+level = "warn"
+check-cfg = [
+    'cfg(ink_abi, values("ink", "sol", "all"))'
+]


### PR DESCRIPTION
## Summary
Follow up to #2033 
- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependent on the specific version of `ink` or `pallet-contracts`?
<!--- Provide a general summary of your changes -->

## Description
<!--- Describe your changes in detail -->

Silences `unexpected_cfg` warnings ([see details](https://blog.rust-lang.org/2024/05/06/check-cfg/#expecting-custom-cfgs)) when "directly" running cargo subcommands (e.g. `cargo clippy`).
See https://github.com/use-ink/ink/issues/2479 for details about the `ink_abi` `cfg` flag.

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have added an entry to `CHANGELOG.md`
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
