### PR TITLE
Allow setting target directory for contract builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make metadata spec arg optional for contract build - [#2047](https://github.com/use-ink/cargo-contract/pull/2047)
 - Update Solidity metadata generation to support `SolEncode` and `SolDecode` implementing arbitrary types - [#2048](https://github.com/use-ink/cargo-contract/pull/2048)
 - Declare `ink_abi` as an expected `cfg` in new project `Cargo.toml` template - [#2058](https://github.com/use-ink/cargo-contract/pull/2058)
+- Allow setting target directory for contract builds - [#2063](https://github.com/use-ink/cargo-contract/pull/2063)
 
 ## [6.0.0-alpha]
 

--- a/crates/build/src/args.rs
+++ b/crates/build/src/args.rs
@@ -259,10 +259,16 @@ pub struct Features {
     features: Vec<String>,
 }
 
+impl From<Vec<String>> for Features {
+    fn from(features: Vec<String>) -> Self {
+        Self { features }
+    }
+}
+
 impl Features {
     /// Appends a feature.
-    pub fn push(&mut self, feature: &str) {
-        self.features.push(feature.to_owned())
+    pub fn push(&mut self, feature: String) {
+        self.features.push(feature)
     }
 
     /// Appends the raw features args to pass through to the `cargo` invocation.

--- a/crates/build/src/docker.rs
+++ b/crates/build/src/docker.rs
@@ -127,13 +127,15 @@ pub fn docker_build(args: ExecuteArgs) -> Result<BuildResult> {
         verbosity,
         output_type,
         image,
+        target_dir,
         ..
     } = args;
     tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()?
         .block_on(async {
-            let crate_metadata = CrateMetadata::collect(&manifest_path)?;
+            let crate_metadata =
+                CrateMetadata::collect_with_target_dir(&manifest_path, target_dir)?;
             let host_folder = std::env::current_dir()?;
             let args = compose_build_args()?;
 

--- a/crates/build/src/solidity_metadata.rs
+++ b/crates/build/src/solidity_metadata.rs
@@ -215,7 +215,7 @@ pub fn generate_metadata(
 /// Get the path of the Solidity compatible contract metadata file.
 pub fn metadata_path(crate_metadata: &CrateMetadata) -> PathBuf {
     let metadata_file = format!("{}.json", crate_metadata.contract_artifact_name);
-    crate_metadata.target_directory.join(metadata_file)
+    crate_metadata.artifact_directory.join(metadata_file)
 }
 
 /// Writes a Solidity compatible metadata file.

--- a/crates/build/src/solidity_metadata/abi.rs
+++ b/crates/build/src/solidity_metadata/abi.rs
@@ -88,7 +88,7 @@ pub fn generate_abi(meta: &ink_metadata::sol::ContractMetadata) -> Result<JsonAb
 /// Get the path of the Solidity compatible contract ABI file.
 pub fn abi_path(crate_metadata: &CrateMetadata) -> PathBuf {
     let metadata_file = format!("{}.abi", crate_metadata.contract_artifact_name);
-    crate_metadata.target_directory.join(metadata_file)
+    crate_metadata.artifact_directory.join(metadata_file)
 }
 
 /// Writes a Solidity compatible ABI file.

--- a/crates/cargo-contract/src/cmd/build.rs
+++ b/crates/cargo-contract/src/cmd/build.rs
@@ -144,6 +144,7 @@ impl BuildCommand {
             output_type,
             image,
             metadata_spec: self.metadata,
+            target_dir: None,
         };
         contract_build::execute(args)
     }
@@ -177,6 +178,7 @@ impl CheckCommand {
             output_type: OutputType::default(),
             image: ImageVariant::Default,
             metadata_spec: Default::default(),
+            target_dir: None,
         };
 
         contract_build::execute(args)


### PR DESCRIPTION
## Summary
Related to https://github.com/use-ink/ink/issues/2520
- [y] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependent on the specific version of `ink` or `pallet-contracts`?
<!--- Provide a general summary of your changes -->

## Description
<!--- Describe your changes in detail -->
- Allow setting target directory for contract builds by introducing a `target_dir` field in `ExecutionArgs`
  - This is currently intended to allow e2e tests infra to share intermediate build artifacts across all contract dependency builds ([see details](https://github.com/use-ink/ink/issues/2520)), so it's currently not exposed as a CLI arg
- Share target directory for intermediate build artifacts for contracts in workspaces (similar to how `cargo` handles target directory in workspaces)
  - Introduces an `artifact_directory` field in `CrateMetadata` allowing only the final build artifacts (i.e. contract binary, metadata e.t.c) to be placed in a separate directory for each workspace member (also similar to [`cargo`'s currently unstable `--artifact-dir` ](https://doc.rust-lang.org/cargo/commands/cargo-build.html#output-options), but only used internally)

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have added an entry to `CHANGELOG.md`
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
