### PR TITLE
Make new-contract template contain only one constructor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,7 +145,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Install nextest
-        uses: taiki-e/install-action@v2.49.50
+        uses: taiki-e/install-action@v2
         with:
           tool: nextest
 
@@ -177,7 +177,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Install nextest
-        uses: taiki-e/install-action@v2.49.50
+        uses: taiki-e/install-action@v2
         with:
           tool: nextest
 
@@ -213,7 +213,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Install nextest
-        uses: taiki-e/install-action@v2.49.50
+        uses: taiki-e/install-action@v2
         with:
           tool: nextest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,7 +204,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        partition: [1, 2]
+        partition: [1, 2, 3, 4]
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -224,7 +224,7 @@ jobs:
 
       - name: Run integration tests
         # The integration tests cannot be run in parallel
-        run: cargo nextest run --archive-file nextest-archive-${{ matrix.os }}.tar.zst --partition count:${{ matrix.partition }}/2 -j 1 -E 'test(integration_tests)'
+        run: cargo nextest run --archive-file nextest-archive-${{ matrix.os }}.tar.zst --partition count:${{ matrix.partition }}/4 -j 1 -E 'test(integration_tests)'
 
   template:
     strategy:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -17,7 +17,7 @@
 # - The latest matching rule, if multiple, takes precedence.
 
 # All of the core team members are global code owners.
-* @cmichi @ascjones
+* @cmichi @davidsemakula @AlexD10S
 
 # CI
-/.github/ @cmichi @ascjones
+/.github/ @cmichi @davidsemakula @AlexD10S

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2360,14 +2360,14 @@ checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
 
 [[package]]
 name = "duct"
-version = "0.13.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4ab5718d1224b63252cd0c6f74f6480f9ffeb117438a2e0f5cf6d9a4798929c"
+checksum = "b6ce170a0e8454fa0f9b0e5ca38a6ba17ed76a50916839d217eb5357e05cdfde"
 dependencies = [
  "libc",
- "once_cell",
  "os_pipe",
  "shared_child",
+ "shared_thread",
 ]
 
 [[package]]
@@ -6701,6 +6701,12 @@ dependencies = [
  "libc",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "shared_thread"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7a6f98357c6bb0ebace19b22220e5543801d9de90ffe77f8abb27c056bac064"
 
 [[package]]
 name = "shlex"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,12 +121,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-abi"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0068ae277f5ee3153a95eaea8ff10e188ed8ccde9b7f9926305415a2c0ab2442"
+checksum = "15516116086325c157c18261d768a20677f0f699348000ed391d4ad0dcb82530"
 dependencies = [
- "alloy-primitives 1.1.0",
- "alloy-sol-type-parser 1.1.0",
+ "alloy-primitives 1.2.1",
+ "alloy-sol-type-parser 1.2.1",
  "serde",
  "serde_json",
 ]
@@ -160,9 +160,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-primitives"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a12fe11d0b8118e551c29e1a67ccb6d01cc07ef08086df30f07487146de6fa1"
+checksum = "6177ed26655d4e84e00b65cb494d4e0b8830e7cae7ef5d63087d445a2600fb55"
 dependencies = [
  "alloy-rlp",
  "bytes",
@@ -303,9 +303,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-sol-type-parser"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "251273c5aa1abb590852f795c938730fa641832fc8fa77b5478ed1bf11b6097e"
+checksum = "10db1bd7baa35bc8d4a1b07efbf734e73e5ba09f2580fb8cee3483a36087ceb2"
 dependencies = [
  "serde",
  "winnow",
@@ -330,8 +330,8 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5460a975434ae594fe2b91586253c1beb404353b78f0a55bf124abcd79557b15"
 dependencies = [
- "alloy-json-abi 1.1.0",
- "alloy-primitives 1.1.0",
+ "alloy-json-abi 1.2.1",
+ "alloy-primitives 1.2.1",
  "alloy-sol-macro 1.1.0",
  "const-hex",
  "serde",
@@ -1802,7 +1802,7 @@ dependencies = [
 name = "contract-build"
 version = "6.0.0-alpha.1"
 dependencies = [
- "alloy-json-abi 0.8.25",
+ "alloy-json-abi 1.2.1",
  "anyhow",
  "blake2",
  "bollard",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1473,13 +1473,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "cargo-platform"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84982c6c0ae343635a3a4ee6dedef965513735c8b183caa7289fa6e27399ebd4"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-util-schemas"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e63d2780ac94487eb9f1fea7b0d56300abc9eb488800854ca217f102f5caccca"
+dependencies = [
+ "semver 1.0.26",
+ "serde",
+ "serde-untagged",
+ "serde-value",
+ "thiserror 1.0.69",
+ "toml",
+ "unicode-xid",
+ "url",
+]
+
+[[package]]
 name = "cargo_metadata"
 version = "0.15.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
 dependencies = [
  "camino",
- "cargo-platform",
+ "cargo-platform 0.1.9",
  "semver 1.0.26",
  "serde",
  "serde_json",
@@ -1488,12 +1513,13 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.19.2"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+checksum = "4f7835cfc6135093070e95eb2b53e5d9b5c403dc3a6be6040ee026270aa82502"
 dependencies = [
  "camino",
- "cargo-platform",
+ "cargo-platform 0.2.0",
+ "cargo-util-schemas",
  "semver 1.0.26",
  "serde",
  "serde_json",
@@ -1780,7 +1806,7 @@ dependencies = [
  "anyhow",
  "blake2",
  "bollard",
- "cargo_metadata 0.19.2",
+ "cargo_metadata 0.20.0",
  "clap",
  "colored 3.0.0",
  "contract-metadata",
@@ -2515,6 +2541,16 @@ name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "erased-serde"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e004d887f51fcb9fef17317a2f3525c887d8aa3f4f50fed920816a688284a5b7"
+dependencies = [
+ "serde",
+ "typeid",
+]
 
 [[package]]
 name = "errno"
@@ -4654,6 +4690,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "os_pipe"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6458,6 +6503,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde-untagged"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "299d9c19d7d466db4ab10addd5703e4c615dec2a5a16dbbafe191045e87ee66e"
+dependencies = [
+ "erased-serde",
+ "serde",
+ "typeid",
+]
+
+[[package]]
+name = "serde-value"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
+dependencies = [
+ "ordered-float",
+ "serde",
 ]
 
 [[package]]
@@ -8326,6 +8392,12 @@ name = "twox-hash"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7b17f197b3050ba473acf9181f7b1d3b66d1cf7356c6cc57886662276e65908"
+
+[[package]]
+name = "typeid"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -20,7 +20,7 @@ blake2 = "0.10.6"
 cargo_metadata = "0.20.0"
 colored = "3.0.0"
 clap = { version = "4.5.28", features = ["derive", "env"] }
-duct = "0.13.7"
+duct = "1.0.0"
 heck = "0.5.0"
 hex = "0.4.3"
 impl-serde = "0.5.0"

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -43,7 +43,7 @@ tokio-stream = "0.1.17"
 bollard = "0.18.1"
 crossterm = "0.28.1"
 itertools = "0.13.0"
-alloy-json-abi = "0.8.20"
+alloy-json-abi = "1.2.1"
 
 polkavm-linker = "0.22.0"
 

--- a/crates/build/Cargo.toml
+++ b/crates/build/Cargo.toml
@@ -17,7 +17,7 @@ include = ["Cargo.toml", "src/**/*.rs", "README.md", "LICENSE", "build.rs", "tem
 regex = "1"
 anyhow = "1.0.95"
 blake2 = "0.10.6"
-cargo_metadata = "0.19.1"
+cargo_metadata = "0.20.0"
 colored = "3.0.0"
 clap = { version = "4.5.28", features = ["derive", "env"] }
 duct = "0.13.7"

--- a/crates/build/src/crate_metadata.rs
+++ b/crates/build/src/crate_metadata.rs
@@ -135,7 +135,7 @@ impl CrateMetadata {
         let mut original_code = target_directory.clone();
         original_code.push(Target::llvm_target_alias());
         original_code.push("release");
-        original_code.push(root_package.name.clone());
+        original_code.push(root_package.name.as_str());
         original_code.set_extension(Target::source_extension());
 
         // {target_dir}/{contract_artifact_name}.code
@@ -147,7 +147,7 @@ impl CrateMetadata {
             .packages
             .iter()
             .find_map(|package| {
-                if package.name == "ink" || package.name == "ink_lang" {
+                if package.name.as_str() == "ink" || package.name.as_str() == "ink_lang" {
                     Some(
                         Version::parse(&package.version.to_string())
                             .expect("Invalid ink crate version string"),

--- a/crates/build/templates/new/lib.rs
+++ b/crates/build/templates/new/lib.rs
@@ -19,14 +19,6 @@ mod {{name}} {
             Self { value: init_value }
         }
 
-        /// Constructor that initializes the `bool` value to `false`.
-        ///
-        /// Constructors can delegate to other constructors.
-        #[ink(constructor)]
-        pub fn default() -> Self {
-            Self::new(Default::default())
-        }
-
         /// A message that can be called on instantiated contracts.
         /// This one flips the value of the stored `bool` from `true`
         /// to `false` and vice versa.


### PR DESCRIPTION
Less error-prone for people opting in to the Solidity ABI, which only allows one constructor.

Our CI fails currently, as the template is also tested with `abi = "sol"`.