### PR TITLE
Fix Solidity metadata generation for overloaded functions and events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed erroneous "[lib] name" warnings - [#2035](https://github.com/use-ink/cargo-contract/pull/2035)
+- Fix Solidity metadata generation for overloaded functions and events - [#2082](https://github.com/use-ink/cargo-contract/pull/2082)
 
 ### Changed
 - Bump the version of `subxt` and `subxt-signer` - [#2036](https://github.com/use-ink/cargo-contract/pull/2036)

--- a/crates/build/src/solidity_metadata/abi.rs
+++ b/crates/build/src/solidity_metadata/abi.rs
@@ -63,17 +63,21 @@ pub fn generate_abi(meta: &ink_metadata::sol::ContractMetadata) -> Result<JsonAb
     }
     let ctor_abi = constructor(ctor)?;
 
-    let fn_abis: BTreeMap<_, _> = meta
-        .functions
-        .iter()
-        .map(|msg| message(msg).map(|fn_abi| (msg.name.to_string(), vec![fn_abi])))
-        .process_results(|iter| iter.collect())?;
+    let mut fn_abis: BTreeMap<String, Vec<Function>> = BTreeMap::new();
+    for msg in &meta.functions {
+        fn_abis
+            .entry(msg.name.to_string())
+            .or_default()
+            .push(message(msg)?);
+    }
 
-    let event_abis: BTreeMap<_, _> = meta
-        .events
-        .iter()
-        .map(|evt| event(evt).map(|evt_abi| (evt.name.to_string(), vec![evt_abi])))
-        .process_results(|iter| iter.collect())?;
+    let mut event_abis: BTreeMap<String, Vec<Event>> = BTreeMap::new();
+    for evt in &meta.events {
+        event_abis
+            .entry(evt.name.to_string())
+            .or_default()
+            .push(event(evt)?);
+    }
 
     Ok(JsonAbi {
         constructor: Some(ctor_abi),


### PR DESCRIPTION
## Summary
Closes #_
- [n] y/n | Does it introduce breaking changes?
- [n] y/n | Is it dependent on the specific version of `ink` or `pallet-contracts`?
<!--- Provide a general summary of your changes -->

## Description
<!--- Describe your changes in detail -->

Overloaded functions and events were previously being "deduplicated" by name

## Checklist before requesting a review
- [x] My code follows the style guidelines of this project
- [x] I have added an entry to `CHANGELOG.md`
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
