### PR TITLE
Remove chain extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Synchronized with `polkadot-sdk/c40b36c3a7c208f9a6837b80812473af3d9ba7f7` ‒ [2102](https://github.com/use-ink/cargo-contract/pull/2102)
 
+### Removed
+- Removed chain extension functionality ‒ [2120](https://github.com/use-ink/cargo-contract/pull/2120)
+
 ## [6.0.0-alpha.1]
 
 ### Added

--- a/crates/cargo-contract/src/cmd/config.rs
+++ b/crates/cargo-contract/src/cmd/config.rs
@@ -67,7 +67,6 @@ impl Environment for Ecdsachain {
     type Hash = <DefaultEnvironment as Environment>::Hash;
     type Timestamp = <DefaultEnvironment as Environment>::Timestamp;
     type BlockNumber = <DefaultEnvironment as Environment>::BlockNumber;
-    type ChainExtension = <DefaultEnvironment as Environment>::ChainExtension;
     type EventRecord = ();
 }
 
@@ -102,7 +101,6 @@ impl Environment for Substrate {
     type Hash = <DefaultEnvironment as Environment>::Hash;
     type Timestamp = <DefaultEnvironment as Environment>::Timestamp;
     type BlockNumber = <DefaultEnvironment as Environment>::BlockNumber;
-    type ChainExtension = <DefaultEnvironment as Environment>::ChainExtension;
     type EventRecord = ();
 }
 
@@ -134,7 +132,6 @@ impl Environment for Polkadot {
     type Hash = <DefaultEnvironment as Environment>::Hash;
     type Timestamp = <DefaultEnvironment as Environment>::Timestamp;
     type BlockNumber = <DefaultEnvironment as Environment>::BlockNumber;
-    type ChainExtension = <DefaultEnvironment as Environment>::ChainExtension;
     type EventRecord = ();
 }
 

--- a/crates/extrinsics/src/env_check.rs
+++ b/crates/extrinsics/src/env_check.rs
@@ -20,7 +20,6 @@ use anyhow::{
 // todo missing comparison for those. not sure if even exposed somewhere.
 impl Environment for DefaultEnvironment {
     const MAX_EVENT_TOPICS: usize = 4;
-    type ChainExtension = NoChainExtension;
 }
 */
 fn get_node_env_fields(
@@ -472,10 +471,6 @@ mod tests {
         let leaf = LeafLayout::from_key::<u8>(LayoutKey::new(0_u8));
         let layout = Layout::Leaf(leaf);
 
-        #[derive(scale_info::TypeInfo)]
-        pub enum NoChainExtension {}
-
-        type ChainExtension = NoChainExtension;
         const MAX_EVENT_TOPICS: usize = 4;
         const NATIVE_TO_ETH_RATIO: u32 = 100_000_000;
         const BUFFER_SIZE: usize = 1 << 14;
@@ -532,12 +527,6 @@ mod tests {
                     .block_number(TypeSpec::with_name_segs::<BN, _>(
                         ::core::iter::Iterator::map(
                             ::core::iter::IntoIterator::into_iter(["BlockNumber"]),
-                            ::core::convert::AsRef::as_ref,
-                        ),
-                    ))
-                    .chain_extension(TypeSpec::with_name_segs::<ChainExtension, _>(
-                        ::core::iter::Iterator::map(
-                            ::core::iter::IntoIterator::into_iter(["ChainExtension"]),
                             ::core::convert::AsRef::as_ref,
                         ),
                     ))


### PR DESCRIPTION
This functionality was removed in `pallet-revive`. The idea is to use pre-compiles instead.