### PR TITLE
Remove `MAX_EVENT_TOPICS` from `Environment` implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 - Removed chain extension functionality ‒ [2120](https://github.com/use-ink/cargo-contract/pull/2120)
+- Remove `MAX_EVENT_TOPICS` from `Environment` implementations - [#2122](https://github.com/use-ink/cargo-contract/pull/2122)
 
 ## [6.0.0-alpha.1]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3745,7 +3745,7 @@ dependencies = [
 [[package]]
 name = "ink"
 version = "6.0.0-alpha.1"
-source = "git+https://github.com/use-ink/ink?branch=master#8c9390fd25f24111c47849f7ae4981b23a2df671"
+source = "git+https://github.com/use-ink/ink?branch=master#aa8c0cabef2b11b512446264b7c12fd5fd72f709"
 dependencies = [
  "const_format",
  "deranged 0.4.0",
@@ -3771,7 +3771,7 @@ dependencies = [
 [[package]]
 name = "ink_allocator"
 version = "6.0.0-alpha.1"
-source = "git+https://github.com/use-ink/ink?branch=master#8c9390fd25f24111c47849f7ae4981b23a2df671"
+source = "git+https://github.com/use-ink/ink?branch=master#aa8c0cabef2b11b512446264b7c12fd5fd72f709"
 dependencies = [
  "cfg-if",
 ]
@@ -3779,7 +3779,7 @@ dependencies = [
 [[package]]
 name = "ink_codegen"
 version = "6.0.0-alpha.1"
-source = "git+https://github.com/use-ink/ink?branch=master#8c9390fd25f24111c47849f7ae4981b23a2df671"
+source = "git+https://github.com/use-ink/ink?branch=master#aa8c0cabef2b11b512446264b7c12fd5fd72f709"
 dependencies = [
  "blake2",
  "derive_more 2.0.1",
@@ -3801,7 +3801,7 @@ dependencies = [
 [[package]]
 name = "ink_engine"
 version = "6.0.0-alpha.1"
-source = "git+https://github.com/use-ink/ink?branch=master#8c9390fd25f24111c47849f7ae4981b23a2df671"
+source = "git+https://github.com/use-ink/ink?branch=master#aa8c0cabef2b11b512446264b7c12fd5fd72f709"
 dependencies = [
  "blake2",
  "derive_more 2.0.1",
@@ -3818,7 +3818,7 @@ dependencies = [
 [[package]]
 name = "ink_env"
 version = "6.0.0-alpha.1"
-source = "git+https://github.com/use-ink/ink?branch=master#8c9390fd25f24111c47849f7ae4981b23a2df671"
+source = "git+https://github.com/use-ink/ink?branch=master#aa8c0cabef2b11b512446264b7c12fd5fd72f709"
 dependencies = [
  "blake2",
  "cfg-if",
@@ -3852,7 +3852,7 @@ dependencies = [
 [[package]]
 name = "ink_ir"
 version = "6.0.0-alpha.1"
-source = "git+https://github.com/use-ink/ink?branch=master#8c9390fd25f24111c47849f7ae4981b23a2df671"
+source = "git+https://github.com/use-ink/ink?branch=master#aa8c0cabef2b11b512446264b7c12fd5fd72f709"
 dependencies = [
  "blake2",
  "either",
@@ -3868,7 +3868,7 @@ dependencies = [
 [[package]]
 name = "ink_macro"
 version = "6.0.0-alpha.1"
-source = "git+https://github.com/use-ink/ink?branch=master#8c9390fd25f24111c47849f7ae4981b23a2df671"
+source = "git+https://github.com/use-ink/ink?branch=master#aa8c0cabef2b11b512446264b7c12fd5fd72f709"
 dependencies = [
  "ink_codegen",
  "ink_ir",
@@ -3883,7 +3883,7 @@ dependencies = [
 [[package]]
 name = "ink_metadata"
 version = "6.0.0-alpha.1"
-source = "git+https://github.com/use-ink/ink?branch=master#8c9390fd25f24111c47849f7ae4981b23a2df671"
+source = "git+https://github.com/use-ink/ink?branch=master#aa8c0cabef2b11b512446264b7c12fd5fd72f709"
 dependencies = [
  "derive_more 2.0.1",
  "impl-serde",
@@ -3898,7 +3898,7 @@ dependencies = [
 [[package]]
 name = "ink_prelude"
 version = "6.0.0-alpha.1"
-source = "git+https://github.com/use-ink/ink?branch=master#8c9390fd25f24111c47849f7ae4981b23a2df671"
+source = "git+https://github.com/use-ink/ink?branch=master#aa8c0cabef2b11b512446264b7c12fd5fd72f709"
 dependencies = [
  "cfg-if",
 ]
@@ -3906,7 +3906,7 @@ dependencies = [
 [[package]]
 name = "ink_primitives"
 version = "6.0.0-alpha.1"
-source = "git+https://github.com/use-ink/ink?branch=master#8c9390fd25f24111c47849f7ae4981b23a2df671"
+source = "git+https://github.com/use-ink/ink?branch=master#aa8c0cabef2b11b512446264b7c12fd5fd72f709"
 dependencies = [
  "alloy-sol-types",
  "cfg-if",
@@ -3934,7 +3934,7 @@ dependencies = [
 [[package]]
 name = "ink_storage"
 version = "6.0.0-alpha.1"
-source = "git+https://github.com/use-ink/ink?branch=master#8c9390fd25f24111c47849f7ae4981b23a2df671"
+source = "git+https://github.com/use-ink/ink?branch=master#aa8c0cabef2b11b512446264b7c12fd5fd72f709"
 dependencies = [
  "array-init",
  "cfg-if",
@@ -3952,7 +3952,7 @@ dependencies = [
 [[package]]
 name = "ink_storage_traits"
 version = "6.0.0-alpha.1"
-source = "git+https://github.com/use-ink/ink?branch=master#8c9390fd25f24111c47849f7ae4981b23a2df671"
+source = "git+https://github.com/use-ink/ink?branch=master#aa8c0cabef2b11b512446264b7c12fd5fd72f709"
 dependencies = [
  "ink_metadata",
  "ink_prelude",

--- a/crates/cargo-contract/src/cmd/config.rs
+++ b/crates/cargo-contract/src/cmd/config.rs
@@ -59,7 +59,6 @@ impl Config for Ecdsachain {
 }
 
 impl Environment for Ecdsachain {
-    const MAX_EVENT_TOPICS: usize = <DefaultEnvironment as Environment>::MAX_EVENT_TOPICS;
     const NATIVE_TO_ETH_RATIO: u32 =
         <DefaultEnvironment as Environment>::NATIVE_TO_ETH_RATIO;
     type AccountId = <DefaultEnvironment as Environment>::AccountId;
@@ -93,7 +92,6 @@ impl Config for Substrate {
 }
 
 impl Environment for Substrate {
-    const MAX_EVENT_TOPICS: usize = <DefaultEnvironment as Environment>::MAX_EVENT_TOPICS;
     const NATIVE_TO_ETH_RATIO: u32 =
         <DefaultEnvironment as Environment>::NATIVE_TO_ETH_RATIO;
     type AccountId = <DefaultEnvironment as Environment>::AccountId;
@@ -124,7 +122,6 @@ impl Config for Polkadot {
 }
 
 impl Environment for Polkadot {
-    const MAX_EVENT_TOPICS: usize = <DefaultEnvironment as Environment>::MAX_EVENT_TOPICS;
     const NATIVE_TO_ETH_RATIO: u32 =
         <DefaultEnvironment as Environment>::NATIVE_TO_ETH_RATIO;
     type AccountId = <DefaultEnvironment as Environment>::AccountId;

--- a/crates/extrinsics/src/env_check.rs
+++ b/crates/extrinsics/src/env_check.rs
@@ -19,7 +19,6 @@ use anyhow::{
 /*
 // todo missing comparison for those. not sure if even exposed somewhere.
 impl Environment for DefaultEnvironment {
-    const MAX_EVENT_TOPICS: usize = 4;
 }
 */
 fn get_node_env_fields(
@@ -470,8 +469,6 @@ mod tests {
         // let _ = generate_metadata();
         let leaf = LeafLayout::from_key::<u8>(LayoutKey::new(0_u8));
         let layout = Layout::Leaf(leaf);
-
-        const MAX_EVENT_TOPICS: usize = 4;
         const NATIVE_TO_ETH_RATIO: u32 = 100_000_000;
         const BUFFER_SIZE: usize = 1 << 14;
 
@@ -530,7 +527,6 @@ mod tests {
                             ::core::convert::AsRef::as_ref,
                         ),
                     ))
-                    .max_event_topics(MAX_EVENT_TOPICS)
                     .native_to_eth_ratio(NATIVE_TO_ETH_RATIO)
                     .static_buffer_size(BUFFER_SIZE)
                     .done(),


### PR DESCRIPTION
## Summary
Follow up to https://github.com/use-ink/ink/pull/2622

- [n] y/n | Does it introduce breaking changes?
- [y] y/n | Is it dependent on the specific version of `ink` or `pallet-contracts`?
<!--- Provide a general summary of your changes -->

## Description
<!--- Describe your changes in detail -->

See https://github.com/use-ink/ink/issues/2601 for details

## Checklist before requesting a review
- [ ] My code follows the style guidelines of this project
- [x] I have added an entry to `CHANGELOG.md`
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
