### PR TITLE
Display payload of a contract revert

### DIFF
--- a/crates/cargo-contract/src/cmd/instantiate.rs
+++ b/crates/cargo-contract/src/cmd/instantiate.rs
@@ -310,9 +310,16 @@ where
         Ok(res) => {
             if res.result.did_revert() {
                 return Err(anyhow!(
-                    "Pre-submission dry-run failed because contract reverted:\n{:?}\n\nUse --skip-dry-run to skip this step.",
-                    String::from_utf8(res.result.data)
-                        .expect("unable to convert to utf8")
+                    "Pre-submission dry-run failed because contract reverted.\n\n\
+                    Contract instantiate executed successfully, but during the execution\n\
+                    the contract consciously decided to revert its state changes.\n\n\
+                    The following data was annotated with the revert operation:\n\n\
+                    Stringified: {}\n\
+                    Raw Bytes:   0x{}\n\
+                    \nUse --skip-dry-run to skip the pre-submission dry-run and submit anyway.\n\
+                    Read more at https://use.ink/docs/v6/contract-debugging/.",
+                    String::from_utf8_lossy(&res.result.data.clone()[1..]),
+                    hex::encode(res.result.data)
                 ));
             }
             if !output_json {


### PR DESCRIPTION
Closes https://github.com/use-ink/cargo-contract/issues/2105.

Here's how it looks for a contract  where the instructor is called with `true`:

```rust
#[ink(constructor)]
pub fn new(init_value: bool) -> Self {
    assert!(!init_value);
    Self { value: init_value }
}
```

<img width="535" height="186" alt="image" src="https://github.com/user-attachments/assets/5608c364-d4ab-4a5c-b9da-abd4490441f3" />

And here for a contract with this message:
```rust
#[ink(message)]
pub fn flip(&mut self) {
    panic!("oh no, something went wrong");
    self.value = !self.value;
}
```

<img width="512" height="198" alt="image" src="https://github.com/user-attachments/assets/5d75634c-8aa3-4917-a787-a2211ce26a65" />
